### PR TITLE
adding the cedar single variant page prediction updates to main singl…

### DIFF
--- a/webapps/variantreport/css/variantreport.css
+++ b/webapps/variantreport/css/variantreport.css
@@ -227,6 +227,11 @@ dl > div {
   grid-template-columns: 12rem auto;
 }
 
+#contdiv_prediction dl > div {
+  grid-template-columns: 16rem auto;
+} 
+
+
 dt {
   line-height: 1.25rem;
   font-weight: 500;
@@ -307,22 +312,10 @@ dd {
   font-weight: bolder;
 }
 
-.preddiv > div {
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 10px;
-  padding-top: 10px;
-  position: relative;
-  bottom: 15px;
+.preddiv {
+  font-size: 1.15rem;
   text-align: center;
-}
-
-.preddiv > div > div:first-child {
-  font-size: 0.75rem;
-}
-
-.preddiv > div > div:nth-child(2) {
-  font-size: 1.25rem;
+  vertical-align: middle;
 }
 
 .contentdiv > div {
@@ -563,19 +556,85 @@ h3 {
   padding-top: 12px;
   padding-bottom: 12px;
   padding-left: 5px;
-  text-align: left;
+  text-align: center;
   background-color: rgb(73 134 189);
   color: white;
   height: 10px;
   position: sticky;
   top: 0;
+  pointer-events: none;
+  
+}
+
+.th_tooltip::after {
+  content: "?";
+  display: inline-block;
+  font-family: sans-serif;
+  font-weight: 400;
+  text-align: center;
+  width: 1.8ex;
+  height: 1.8ex;
+  font-size: 12px;
+  border-radius: 18.2ex;
+  padding: 2px;
+  color: white;
+  background: transparent;
+  border: 1px solid white;
+  text-decoration: none;
+  margin-left: 4px;
+  vertical-align: center;
+  cursor: pointer;
+  pointer-events: all;
+}
+
+.show_tooltip { 
+  display: block;
+}
+
+.hide_tooltip {
+  display: none;
+}
+
+#rankscore_info {
+  position: absolute;
+  left: 75%;
+  z-index: 3;
+  background-color: white;
+  padding: 10px;
+  width: 250px;
+  box-shadow: 4px 4px 4px gray;
+  border: 1px dashed gray;
+  word-break: normal;
+}
+
+#prediction_info {
+  position: absolute;
+  left: 40%;
+  z-index: 3;
+  background-color: white;
+  padding: 10px;
+  width: 250px;
+  box-shadow: 4px 4px 4px gray;
+  border: 1px dashed gray;
+  word-break: normal;
+}
+
+#score_info {
+  position: absolute;
+  left: 57%;
+  z-index: 3;
+  background-color: white;
+  padding: 10px;
+  width: 250px;
+  box-shadow: 4px 4px 4px gray;
+  border: 1px dashed gray;
+  word-break: normal;
 }
 
 #pred {
   font-family: Arial, Helvetica, sans-serif;
   border-collapse: collapse;
   width: 100%;
-
   background-color: white;
   border-radius: 9px;
 }
@@ -595,17 +654,23 @@ h3 {
 .pred_damaging {
   color: rgba(153, 27, 27, 1);
   position: relative;
-  top: 25px;
 }
 .pred_tol {
   color: rgba(6, 95, 70, 1);
   position: relative;
-  top: 25px;
+}
+
+.pred_uncertain {
+  color: black;
+  position: relative;
+}
+.pred_tol {
+  color: rgba(6, 95, 70, 1);
+  position: relative;
 }
 .pred_noanno {
   color: darkgrey;
   position: relative;
-  top: 40px;
   font-size: 1rem;
   text-align: center;
 }
@@ -613,13 +678,12 @@ h3 {
   background-color: white;
   color: black;
   position: relative;
-  top: 25px;
 }
 #pred td {
   padding-bottom: 15px;
   padding-top: 15px;
-  vertical-align: top;
-  height: 126px;
+  height: 75px;
+  vertical-align: middle;
 }
 #pred tr {
   border: 1px solid #ddd;
@@ -904,4 +968,26 @@ h3 {
 
 #detaildiv_documentation > h1 {
   margin-block-end: 1em;
+}
+
+.prediction {
+  overflow: auto;
+  padding-left: 1.5rem;
+  padding-right: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.prediction canvas {
+  max-height: 203px;
+}
+.prediction span{
+  background-color: white;
+  padding: 5px;
+  border: 1px solid black;
+  max-width: 192px;
+  display: flex;
+  justify-content: center;
+  margin-top: 15px;
+  font-size: 15px;
 }

--- a/webapps/variantreport/js/main.js
+++ b/webapps/variantreport/js/main.js
@@ -969,24 +969,17 @@ const getDialWidget2 = function(title, value, threshold, score) {
     addEl(sdiv, ssdiv)
     return sdiv
 }
-const predWidget = function(title, value) {
-    var sdiv = getEl('div');
-    sdiv.classList.add('preddiv')
-    var ssdiv = getEl('div')
-    var sssdiv = getEl('div')
-    sssdiv.textContent = title
-    addEl(ssdiv, sssdiv)
-    sssdiv = getEl('div')
-    sssdiv.textContent = value
+const predWidget = function (value) {
+    var div = getEl('div');
+    div.classList.add('preddiv')
     if (isNaN(value) == false && value != null) {
-        sssdiv.textContent = prettyVal(value)
+        div.textContent = prettyVal(value)
     } else {
-        sssdiv.textContent = value
+        div.textContent = value
     }
-    addEl(ssdiv, sssdiv)
-    addEl(sdiv, ssdiv)
-    return sdiv
+    return div
 }
+
 const contentWidget = function(title, value) {
     var sdiv = getEl('div');
     sdiv.classList.add('contentdiv')
@@ -4029,7 +4022,7 @@ widgetGenerators['predictionpanel'] = {
     'variant': {
         'width': '100%',
         'height': undefined,
-        'function': function(div, row, tabName) {
+        'function': function (div, row, tabName) {
             var dl = getEl('dl')
             dl.style.width = 'calc(100% - 1rem)'
             addEl(div, dl)
@@ -4041,385 +4034,205 @@ widgetGenerators['predictionpanel'] = {
             var wdiv = getEl('div')
             wdiv.style.display = 'flex'
             wdiv.style.flexWrap = 'wrap'
-            var divHeight = '100%';
             var scores = [];
             var rankscores = [];
-            var preds = [];
             var predictions = [];
             var names = ['dann_coding', 'fathmm', 'fathmm_mkl', 'fathmm_xf_coding', 'lrt', 'metalr', 'metasvm', 'mutation_assessor', 'mutpred1', 'mutationtaster2', 'polyphen2hdiv', 'polyphen2hvar', 'provean2', 'revel2', 'sift2', 'vest2'];
+            
+            // Dann Coding
+            // no prediction for Dann Coding
+            predictions.push(predWidget(null));
             var dann_score = getWidgetData(tabName, 'dann_coding', row, 'dann_coding_score');
-            if (dann_score != undefined || dann_score != null) {
-                var dann = predWidget('coding score', dann_score);
-                scores.push(dann);
-                predictions.push(null);
-                var pred = predWidget(null, null);
-                preds.push(pred);
-            } else {
-                var dann = predWidget(null, null);
-                scores.push(dann);
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-            }
             var dann_rankscore = getWidgetData(tabName, 'dann_coding', row, 'dann_rankscore');
-            if (dann_rankscore != undefined || dann_rankscore != null) {
-                var dann = getDialWidget('coding rankscore', dann_rankscore, 0.80);
-                rankscores.push(dann);
-            } else {
-                var dann = predWidget(null, null);
-                rankscores.push(dann);
-            }
+            scores.push(predWidget(dann_score));
+            rankscores.push(predWidget(dann_rankscore));
+
+            // Fathmm
             var fathmm_score = getWidgetData(tabName, 'fathmm', row, 'fathmm_score');
             if (fathmm_score != undefined || fathmm_score != null) {
-                scores.push(predWidget('score', fathmm_score));
+                let scoreArray = fathmm_score.split(";").map(Number);
+                let maxIndex;
+                if (fathmm_score.endsWith(';.')) {
+                    maxIndex = 0
+                } else {
+                    maxIndex = scoreArray.indexOf(Math.max(...scoreArray));
+                }
+                scores.push(predWidget(scoreArray[maxIndex]));
                 var fathmm_pred = getWidgetData(tabName, 'fathmm', row, 'fathmm_pred');
-                predictions.push(fathmm_pred);
-                preds.push(predWidget('prediction', fathmm_pred));
+                var predArray = fathmm_pred.split(";");
+                let prediction;
+                if (predArray[maxIndex] === "T") {
+                    prediction = "Tolerated"
+                } else if (predArray[maxIndex] === "D") {
+                    prediction = "Damaging"
+                }
+                predictions.push(predWidget(prediction));
             } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
+                scores.push(predWidget(null));
+                predictions.push(predWidget(null));
             }
             var fathmm_rankscore = getWidgetData(tabName, 'fathmm', row, 'fathmm_rscore');
             if (fathmm_rankscore != undefined || fathmm_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', fathmm_rankscore, 0.80));
+                rankscores.push(predWidget(fathmm_rankscore));
             } else {
-                rankscores.push(predWidget(null, null));
+                rankscores.push(predWidget(null));
             }
 
+            // Fathmm Mkl
+            var mkl_pred = getWidgetData(tabName, 'fathmm_mkl', row, 'fathmm_mkl_coding_pred');
+            predictions.push(predWidget(mkl_pred))
             var mkl_score = getWidgetData(tabName, 'fathmm_mkl', row, 'fathmm_mkl_coding_score');
-            if (mkl_score != undefined || mkl_score != null) {
-                var mkl = predWidget('coding score', mkl_score);
-                scores.push(mkl);
-                var mkl_pred = getWidgetData(tabName, 'fathmm_mkl', row, 'fathmm_mkl_coding_pred');
-                predictions.push(mkl_pred);
-                var pred = predWidget('prediction', mkl_pred);
-                preds.push(pred);
-            } else {
-                var mkl = predWidget(null, null);
-                scores.push(mkl);
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(mkl_score));
             var mkl_rankscore = getWidgetData(tabName, 'fathmm_mkl', row, 'fathmm_mkl_coding_rankscore');
-            if (mkl_rankscore != undefined || mkl_rankscore != null) {
-                var mkl = getDialWidget('coding rankscore', mkl_rankscore, 0.28317);
-                rankscores.push(mkl);
-            } else {
-                var mkl = predWidget(null, null);
-                rankscores.push(mkl);
-            }
+            rankscores.push(predWidget(mkl_rankscore))
+
+            // Fathmm xf
+            var xf_pred = getWidgetData(tabName, 'fathmm_xf_coding', row, 'fathmm_xf_coding_pred');
+            predictions.push(predWidget(xf_pred))
             var xf_score = getWidgetData(tabName, 'fathmm_xf_coding', row, 'fathmm_xf_coding_score');
-            if (xf_score != undefined || xf_score != null) {
-                var xf = predWidget('coding score', xf_score);
-                scores.push(xf);
-                var xf_pred = getWidgetData(tabName, 'fathmm_xf_coding', row, 'fathmm_xf_coding_pred');
-                predictions.push(xf_pred);
-                var pred = predWidget('prediction', xf_pred);
-                preds.push(pred);
-            } else {
-                var xf = predWidget(null, null);
-                scores.push(xf);
-                var ssdiv = getEl('div')
-                ssdiv.classList.add('pred_noanno')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(xf_score))
             var xf_rankscore = getWidgetData(tabName, 'fathmm_xf_coding', row, 'fathmm_xf_coding_rankscore');
-            if (xf_rankscore != undefined || xf_rankscore != null) {
-                var xf = getDialWidget('coding rankscore', xf_rankscore, 0.50);
-                rankscores.push(xf);
-            } else {
-                var xf = predWidget(null, null);
-                rankscores.push(xf);
-            }
+            rankscores.push(predWidget(xf_rankscore))
+
+            // lrt
+            var lrt_pred = getWidgetData(tabName, 'lrt', row, 'lrt_pred');
+            predictions.push(predWidget(lrt_pred))
             var lrt_score = getWidgetData(tabName, 'lrt', row, 'lrt_score');
-            if (lrt_score != undefined || lrt_score != null) {
-                var l = predWidget('coding score', lrt_score);
-                scores.push(l);
-                var lrt_pred = getWidgetData(tabName, 'lrt', row, 'lrt_pred');
-                predictions.push(lrt_pred);
-                var pred = predWidget('prediction', lrt_pred);
-                preds.push(pred);
-
-            } else {
-                var l = predWidget(null, null);
-                scores.push(l);
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(lrt_score))
             var lrt_rankscore = getWidgetData(tabName, 'lrt', row, 'lrt_converted_rankscore');
-            if (lrt_rankscore != undefined || lrt_rankscore != null) {
-                var lrt = getDialWidget('coding rankscore', lrt_rankscore, 0.80);
-                rankscores.push(lrt);
-            } else {
-                var lrt = predWidget(null, null);
-                rankscores.push(lrt);
-            }
+            rankscores.push(predWidget(lrt_rankscore))
+
+            // metalr
+            var metalr_pred = getWidgetData(tabName, 'metalr', row, 'pred');
+            predictions.push(predWidget(metalr_pred));
             var metalr_score = getWidgetData(tabName, 'metalr', row, 'score');
-            if (metalr_score != undefined || metalr_score != null) {
-                var metalr = predWidget('coding score', metalr_score);
-                scores.push(metalr);
-                var metalr_pred = getWidgetData(tabName, 'metalr', row, 'pred');
-                predictions.push(metalr_pred);
-                var pred = predWidget('prediction', metalr_pred);
-                preds.push(pred);
-            } else {
-                var metalr = predWidget(null, null);
-                scores.push(metalr);
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(metalr_score))
             var metalr_rankscore = getWidgetData(tabName, 'metalr', row, 'rankscore');
-            if (metalr_rankscore != undefined || metalr_rankscore != null) {
-                var metalr = getDialWidget('rankscore', metalr_rankscore, 0.81101);
-                rankscores.push(metalr);
-
-            } else {
-                var metalr = predWidget(null, null);
-                rankscores.push(metalr);
-            }
+            rankscores.push(predWidget(metalr_rankscore))
+    
+            // metasvm
+            var metasvm_pred = getWidgetData(tabName, 'metasvm', row, 'pred');
+            predictions.push(predWidget(metasvm_pred))
             var metasvm_score = getWidgetData(tabName, 'metasvm', row, 'score');
-            if (metasvm_score != undefined || metasvm_score != null) {
-                var metasvm = predWidget('score', metasvm_score);
-                scores.push(metasvm);
-                var metasvm_pred = getWidgetData(tabName, 'metasvm', row, 'pred');
-                predictions.push(metasvm_pred);
-                var pred = predWidget('prediction', metasvm_pred);
-                preds.push(pred);
-            } else {
-                var metasvm = predWidget(null, null);
-                scores.push(metasvm);
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(metasvm_score))
             var metasvm_rankscore = getWidgetData(tabName, 'metasvm', row, 'rankscore');
-            if (metasvm_rankscore != undefined || metasvm_rankscore != null) {
-                var metasvm = getDialWidget('rankscore', metasvm_rankscore, 0.82257);
-                rankscores.push(metasvm);
-            } else {
-                var metasvm = predWidget(null, null);
-                rankscores.push(metasvm);
-            }
-            var muta_score = getWidgetData(tabName, 'mutation_assessor', row, 'mut_score');
-            if (muta_score != undefined || muta_score != null) {
-                scores.push(predWidget('score', muta_score));
-                var muta_pred = getWidgetData(tabName, 'mutation_assessor', row, 'mut_pred');
-                predictions.push(muta_pred);
-                preds.push(predWidget('prediction', muta_pred));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.classList.add('pred_noanno')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
-            var muta_rankscore = getWidgetData(tabName, 'mutation_assessor', row, 'mut_rscore');
-            if (muta_rankscore != undefined || muta_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', muta_rankscore, 0.80));
-            } else {
-                rankscores.push(predWidget(null, null));
-            }
+            rankscores.push(predWidget(metasvm_rankscore))
+
+            // Mutation Assessor
+            var muta_pred = getWidgetData(tabName, 'mutation_assessor', row, 'impact');
+            predictions.push(predWidget(muta_pred))
+            var muta_score = Number(getWidgetData(tabName, 'mutation_assessor', row, 'score'));
+            scores.push(predWidget(muta_score))
+            var muta_rankscore = Number(getWidgetData(tabName, 'mutation_assessor', row, 'rankscore'));
+            rankscores.push(predWidget(muta_rankscore))
+
+            // mutpred
+            // mutpred offers no prediction
+            predictions.push(predWidget(null))
             var mutpred_score = getWidgetData(tabName, 'mutpred1', row, 'mutpred_general_score');
-            if (mutpred_score != undefined || mutpred_score != null) {
-                scores.push(predWidget('score', mutpred_score));
-                predictions.push(null);
-                preds.push(predWidget(null, null));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(mutpred_score))
             var mutpred_rankscore = getWidgetData(tabName, 'mutpred1', row, 'mutpred_rankscore');
-            if (mutpred_rankscore != undefined || mutpred_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', mutpred_rankscore, 0.80));
-            } else {
-                rankscores.push(predWidget(null, null));
-            }
+            rankscores.push(predWidget(mutpred_rankscore))
 
+            // mutation taster
+            var taster_pred = getWidgetData(tabName, 'mutationtaster', row, 'prediction');
+            predictions.push(predWidget(taster_pred))
             var taster_score = getWidgetData(tabName, 'mutationtaster', row, 'score');
-            if (taster_score != undefined || taster_score != null) {
-                scores.push(predWidget('score', taster_score));
-                var taster_pred = getWidgetData(tabName, 'mutationtaster', row, 'prediction');
-                predictions.push(taster_pred);
-                preds.push(predWidget('prediction', taster_pred));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(taster_score))
             var taster_rankscore = getWidgetData(tabName, 'mutationtaster', row, 'rankscore');
-            if (taster_rankscore != undefined || taster_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', taster_rankscore, 0.31733));
-            } else {
-                rankscores.push(predWidget(null, null));
+            rankscores.push(predWidget(taster_rankscore))
+            
+            // polyphen hdiv
+            let hdiv_pred = getWidgetData(tabName, 'polyphen2', row, 'hdiv_pred');
+            if (hdiv_pred == 'D') {
+                hdiv_pred = 'Probably Damaging';
+            } else if (hdiv_pred == 'P') {
+                hdiv_pred = 'Possibly Damaging';
+            } else if (hdiv_pred == 'B') {
+                hdiv_pred = 'Benign';
             }
+            predictions.push(predWidget(hdiv_pred))
             var hdiv_score = getWidgetData(tabName, 'polyphen2', row, 'hdiv_score');
-            if (hdiv_score != undefined || hdiv_score != null) {
-                scores.push(predWidget('score', hdiv_score));
-                var hdiv_pred = getWidgetData(tabName, 'polyphen2', row, 'hdiv_pred');
-                if (hdiv_pred == 'D') {
-                    hdiv_pred = 'Probably Damaging';
-                } else if (hdiv_pred == 'P') {
-                    hdiv_pred = 'Possibly Damaging';
-                } else if (hdiv_pred == 'B') {
-                    hdiv_pred = 'Benign';
-                }
-                predictions.push(hdiv_pred);
-                preds.push(predWidget('prediction', hdiv_pred));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(hdiv_score))
             var hdiv_rankscore = getWidgetData(tabName, 'polyphen2', row, 'hdiv_rank');
-            if (hdiv_rankscore != undefined || hdiv_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', hdiv_rankscore, 0.37043));
-            } else {
-                rankscores.push(predWidget(null, null));
+            rankscores.push(predWidget(hdiv_rankscore))
+            
+            // polyphen hvar
+            let hvar_pred = getWidgetData(tabName, 'polyphen2', row, 'hvar_pred');
+            if (hvar_pred == 'D') {
+                hvar_pred = 'Probably Damaging';
+            } else if (hvar_pred == 'P') {
+                hvar_pred = 'Possibly Damaging';
+            } else if (hvar_pred == 'B') {
+                hvar_pred = 'Benign';
             }
+            predictions.push(predWidget(hvar_pred))
             var hvar_score = getWidgetData(tabName, 'polyphen2', row, 'hvar_score');
-            if (hvar_score != undefined || hvar_score != null) {
-                scores.push(predWidget('score', hvar_score));
-                var hvar_pred = getWidgetData(tabName, 'polyphen2', row, 'hvar_pred');
-                if (hvar_pred == 'D') {
-                    hvar_pred = 'Probably Damaging';
-                } else if (hvar_pred == 'P') {
-                    hvar_pred = 'Possibly Damaging';
-                } else if (hvar_pred == 'B') {
-                    hvar_pred = 'Benign';
-                }
-                predictions.push(hvar_pred);
-                preds.push(predWidget('prediction', hvar_pred));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(hvar_score))
             var hvar_rankscore = getWidgetData(tabName, 'polyphen2', row, 'hvar_rank');
-            if (hvar_rankscore != undefined || hvar_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', hvar_rankscore, 0.47121));
-            } else {
-                rankscores.push(predWidget(null, null));
-            }
+            rankscores.push(predWidget(hvar_rankscore))
+            
+            // provean
+            var provean_pred = getWidgetData(tabName, 'provean', row, 'prediction');
+            predictions.push(predWidget(provean_pred))
             var provean_score = getWidgetData(tabName, 'provean', row, 'score');
-            if (provean_score != undefined || provean_score != null) {
-                scores.push(predWidget('score', provean_score));
-                var provean_pred = getWidgetData(tabName, 'provean', row, 'prediction');
-                predictions.push(provean_pred);
-                preds.push(predWidget('prediction', provean_pred));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(provean_score))
             var provean_rankscore = getWidgetData(tabName, 'provean', row, 'rankscore');
-            if (provean_rankscore != undefined || provean_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', provean_rankscore, 0.54382));
-            } else {
-                rankscores.push(predWidget(null, null));
+            rankscores.push(predWidget(provean_rankscore))
 
-            }
+            // revel
             var revel_score = getWidgetData(tabName, 'revel', row, 'score');
-            if (revel_score != null || revel_score != undefined) {
-                var r = predWidget('score', revel_score);
-                scores.push(r);
-                predictions.push(null);
-                var pred = predWidget(null, null);
-                preds.push(pred);
-            } else {
-                var r = predWidget(null, null);
-                scores.push(r);
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(revel_score))
             var revel_rankscore = getWidgetData(tabName, 'revel', row, 'rankscore');
-            if (revel_rankscore != null || revel_rankscore != undefined) {
-                var revel = getDialWidget('rankscore', revel_rankscore, 0.80);
-                rankscores.push(revel);
-            } else {
-                var revel = predWidget(null, null);
-                rankscores.push(revel);
+            rankscores.push(predWidget(revel_rankscore))
+            let revel_pred = null
+            if (revel_score !== null) {
+                if (revel_score <= 0.183) {
+                    revel_pred = "Benign"
+                } else if (revel_score >= 0.773) {
+                    revel_pred = "Pathogenic"
+                } else {
+                    revel_pred = "Uncertain"
+                }
+            }
+            predictions.push(predWidget(revel_pred))
 
-            }
+            // sift
+            var sift_pred = getWidgetData(tabName, 'sift', row, 'prediction');
+            predictions.push(predWidget(sift_pred))
             var sift_score = getWidgetData(tabName, 'sift', row, 'score');
-            if (sift_score != undefined || sift_score != null) {
-                scores.push(predWidget('score', sift_score));
-                var sift_pred = getWidgetData(tabName, 'sift', row, 'prediction');
-                predictions.push(sift_pred);
-                preds.push(predWidget('prediction', sift_pred));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
-            }
+            scores.push(predWidget(sift_score))
             var sift_rankscore = getWidgetData(tabName, 'sift', row, 'rankscore');
-            if (sift_rankscore != undefined || sift_rankscore != null) {
-                rankscores.push(getDialWidget('rankscore', sift_rankscore, 0.80));
-            } else {
-                rankscores.push(predWidget(null, null));
-            }
+            rankscores.push(predWidget(sift_rankscore))
+            
+            // vest
             var vest_score = getWidgetData(tabName, 'vest', row, 'score');
-            var vest_pval = getWidgetData(tabName, 'vest', row, 'pval');
-            if (vest_score != undefined || vest_score != null) {
-                scores.push(predWidget('p-value', vest_pval));
-                predictions.push(null);
-                preds.push(predWidget(null, null));
-            } else {
-                scores.push(predWidget(null, null));
-                var ssdiv = getEl('div')
-                ssdiv.textContent = getNoAnnotMsgVariantLevel()
-                ssdiv.classList.add('pred_noanno')
-                preds.push(ssdiv)
-                predictions.push(null);
+            scores.push(predWidget(vest_score))
+            // vest provides no rank score
+            rankscores.push(predWidget(null))
+            let vest_pred = null
+            if (vest_score != null) {
+                if (vest_score <= 0.302) {
+                    vest_pred = "Benign"
+                } else if ( vest_score >= 0.861) {
+                    vest_pred = "Pathogenic"
+                } else {
+                    vest_pred = "Uncertain"
+                }
             }
-            if (vest_score != undefined || vest_score != null) {
-                rankscores.push(getDialWidget('score', vest_score, 0.80));
-            } else {
-                rankscores.push(predWidget(null, null));
-            }
+            predictions.push(predWidget(vest_pred));
+
             var table = getWidgetTableFrame();
             table.setAttribute("id", "pred");
             var tbody = getEl('tbody');
+            tooltipContent = [
+                {id: "source", label: "Source", info: null},
+                {id: "prediction", label: "Prediction", info: "Predictions, when provided, indicate the predicted outcome or impact of the variant. \n \n NOTE: Revel and Vest4.0 prediction output is based upon threshold ranges provided by Pejaver, Vikas et al. 'Calibration of computational tools for missense variant pathogenicity classification and ClinGen recommendations for PP3/BP4 criteria.' American journal of human genetics vol. 109,12 (2022): 2163-2177. doi:10.1016/j.ajhg.2022.10.013"},
+                {id: "score", label: "Score", info: "Raw scores reported by the method."},
+                {id: "rankscore", label: "Rankscore", info: "When provided rankscores closer to 0 are considered more tolerated, while rankscores closer to 1 are considered more damaging."}
+            ]
+            var thead = getWidgetTableHeadTooltips(tooltipContent);
+            addEl(table, thead);
             var sdiv = getEl('div');
             var sdiv = getEl('div')
             sdiv.style.maxWidth = '75rem'
@@ -4429,31 +4242,36 @@ widgetGenerators['predictionpanel'] = {
             var counts = [];
             var dam_count = 0;
             var tol_count = 0;
+            var uncertain_count = 0;
             for (var i = 0; i < names.length; i++) {
                 var name = names[i];
                 var titleEl = makeModuleDescUrlTitle(name)
-                var p = predictions[i];
                 var tr = document.createElement('tr');
                 var td = document.createElement('td');
                 td.style.textAlign = 'center';
                 td.style.verticalAlign = 'middle';
                 addEl(tr, td);
                 addEl(td, titleEl)
-                var pred = preds[i];
+                var pred = predictions[i];
+                var p = pred.textContent
                 var score = scores[i];
-                if (score != null) {
+                if (score.textContent !== "") {
                     score.classList.add('pred_score');
+                } else {
+                    pred.textContent = getNoAnnotMsgVariantLevel()
+                    pred.classList.add("pred_noanno")
                 }
                 var td = document.createElement('td');
-                if (p != null && p.includes('Damaging') || p == 'Medium' || p == 'Disease Causing') {
+                if (p.includes('Damaging') || p == 'Medium' || p == 'Disease Causing' ||  p == "Pathogenic") {
                     dam_count = dam_count + 1;
                     pred.classList.add('pred_damaging');
-                } else if (p != null) {
+                } else if ( p === "Uncertain") {
+                    uncertain_count = uncertain_count + 1
+                    pred.classList.add('pred_uncertain');
+                } else if (p != "") {
                     tol_count = tol_count + 1;
                     pred.classList.add('pred_tol');
                 }
-                var a = getEl('a')
-                var tn = document.createTextNode(pred)
                 addEl(tr, td);
                 addEl(td, pred)
                 var td = document.createElement('td');
@@ -4461,34 +4279,35 @@ widgetGenerators['predictionpanel'] = {
                 addEl(tr, td);
                 var rank = rankscores[i];
                 var td = document.createElement('td');
-
                 addEl(td, rank);
                 addEl(tr, td);
                 addEl(tbody, tr);
             }
             counts.push(dam_count);
             counts.push(tol_count);
+            counts.push(uncertain_count);
+            var total_count = dam_count + tol_count + uncertain_count
             addEl(wdiv, addEl(sdiv, addEl(table, tbody)));
             var sdiv = getEl('div');
-            sdiv.style.overflow = 'auto';
-            sdiv.style.paddingLeft = '1rem'
-            sdiv.style.paddingRight = '1rem'
+            sdiv.className = "prediction"
             var chartDiv = getEl('canvas');
+            var span = getEl('span')
+            span.innerHTML = tol_count + "/" + total_count + " Tolerated or Benign"
             addEl(sdiv, chartDiv);
+            addEl(sdiv, span)
             var chart = new Chart(chartDiv, {
                 type: 'doughnut',
                 data: {
                     datasets: [{
                         data: counts,
-                        backgroundColor: ['rgba(153, 27, 27, 1)', 'rgba(6, 95, 70, 1)']
+                        backgroundColor: ['rgba(153, 27, 27, 1)', 'rgba(6, 95, 70, 1)', 'black']
                     }],
-                    labels: ['Damaging', 'Tolerated']
+                    labels: ['Damaging / Pathogenic', 'Tolerated / Benign', 'Uncertain']
                 },
                 options: {
                     responsive: true,
                     responsiveAnimationDuration: 500,
                     maintainAspectRatio: false,
-
                     legend: {
                         display: false,
                         position: 'right',
@@ -4496,7 +4315,7 @@ widgetGenerators['predictionpanel'] = {
                     plugins: {
                         labels: {
                             render: 'label',
-                            fontColor: 'white',
+                            fontColor: 'black',
                             overlap: false,
                             outsidePadding: 4,
                         }

--- a/webapps/variantreport/js/widgethelper.js
+++ b/webapps/variantreport/js/widgethelper.js
@@ -38,6 +38,39 @@ function getWidgetTableHead(headers, widths) {
     return thead;
 }
 
+function getWidgetTableHeadTooltips(content) {
+    var thead = getEl('thead');
+    thead.style.textAlign = 'left';
+    thead.style['word-break'] = 'normal';
+    thead.style.borderBottom = widgetTableBorderStyle;
+    var tr = getEl('tr');
+    content.map((header) => {
+        var th = getEl('th');
+        if (header.info) {
+            th.classList.add("th_tooltip")
+            var div = getEl("div")
+            div.setAttribute("id", `${header.id}_info`)
+            div.classList.add("hide_tooltip")
+            div.innerText = header.info
+            addEl(thead, div)
+            th.addEventListener('click', function (evt) {
+                var el = document.getElementById(`${header.id}_info`)
+                el.classList.remove("hide_tooltip")
+                el.classList = "show_tooltip"
+            });
+            div.addEventListener('mouseout', function (evt) {
+                var el = document.getElementById(`${header.id}_info`)
+                el.classList.remove("show_tooltip")
+                el.classList = "hide_tooltip"
+            });
+        }
+        addEl(th, getTn(header.label));
+        addEl(tr, th);
+    })
+    addEl(thead, tr);
+    return thead;
+}
+
 function getWidgetTableTr(values, linkNames) {
     var numBorder = values.length - 1;
     var linkNameItr = 0;

--- a/webapps/variantreport/variantreport.yml
+++ b/webapps/variantreport/variantreport.yml
@@ -1,5 +1,5 @@
 title: OpenCRAVAT Variant Report
-version: 1.2.2
+version: 1.3.0
 type: webapp
 live_modules:
 - aloft
@@ -184,6 +184,7 @@ developer:
   website: 
   citation: ''
 release_note:
+  1.3.0: updated variant effect predictions panel
   1.2.2: works with updated phylop and phastcons
   1.2.1: show documentation on blank page
   1.2.0: change input to multiple boxes, update documentation link


### PR DESCRIPTION
adding the cedar single variant page prediction updates to main single variant page. This includes the reformatting of the table with tooltips in the header, revel and vest4 have prediction output now, a little reformatting of the donut chart.