### PR TITLE
feat/hgvs converter: Add Converter for HGVS Input

### DIFF
--- a/converters/hgvs-converter/hgvs-converter.md
+++ b/converters/hgvs-converter/hgvs-converter.md
@@ -1,0 +1,13 @@
+# HGVS Converter
+
+Converts from a list of HGVS strings. This is enabled by a proxy api that converts HGVS strings to genomic coordinates using the HGVS python package.
+
+Example Input:
+
+```text
+# HGVS strings one per line
+# Comments are allowed with a # at the beginning of the line
+NC_000023.11:g.32389644G>A
+NM_001002261.3:c.805_809del5
+NM_004333.4:c.1799T>A
+```

--- a/converters/hgvs-converter/hgvs-converter.py
+++ b/converters/hgvs-converter/hgvs-converter.py
@@ -1,0 +1,60 @@
+from cravat import BaseConverter
+from cravat import BadFormatError
+
+
+class HGVSConverter(BaseConverter):
+    """
+        HGVS Input format:
+        One HGVS string per line
+        Comment lines start with #
+        Sample column (?)
+        Tag column(?)
+        Sample is an optional sample identifier for cohort studies
+        Tags is a string with identifiers or categorical tags. It is also
+        optional and is delimited with semicolons if there is more than one
+        tag.
+    """
+    def __init__(self):
+        super(HGVSConverter, self).__init__()
+        self.format_name = 'hgvs'
+
+    def _check_line(self, l):
+        toks = l.strip('\r\n').split('\t')
+        if len(toks) == 1:
+            toks = toks[0].split()
+        return True, ''
+    
+    def check_format(self, f):
+        format_correct = False
+        for l in f:
+            if not (l.startswith('#')):
+                format_correct, _ = self._check_line(l)
+                if format_correct:
+                    break
+        return format_correct
+    
+    def setup(self, f):
+        # Do some API connection test?
+        pass
+
+    def _call_api(self, hgvs):
+        # pass
+        return 'chr1', 10100, '+', 'C', 'T', 's0'
+
+    def convert_line(self, l):
+        l.lstrip()
+        if l.startswith('#'): return self.IGNORE
+        format_correct, format_msg = self._check_line(l)
+        if not format_correct: raise BadFormatError(format_msg)
+
+        toks = self._call_api('')
+        chrom, pos, strand, ref, alt, sample, tags = toks
+        wdict = {
+            'tags':tags,
+             'chrom':chrom,
+             'pos':pos,
+             'ref_base':ref,
+             'alt_base':alt,
+             'sample_id':sample,
+             }
+        return [wdict]

--- a/converters/hgvs-converter/hgvs-converter.yml
+++ b/converters/hgvs-converter/hgvs-converter.yml
@@ -10,4 +10,4 @@ developer:
   citation: ''
 requires_opencravat: '>=1.8.0'
 release_note:
-  0.1.0: Alpha release of HGVS input
+  0.1.0: Initial release of HGVS input

--- a/converters/hgvs-converter/hgvs-converter.yml
+++ b/converters/hgvs-converter/hgvs-converter.yml
@@ -1,7 +1,8 @@
 title: HGVS Converter
-version: 0.1.0
+version: 1.0.0
 type: converter
 description: File converter for HGVS string input
+api_url: https://hgvs.opencravat.org
 developer:
   name: Kyle Anderson
   organization: Potomac IT Group
@@ -10,4 +11,4 @@ developer:
   citation: ''
 requires_opencravat: '>=1.8.0'
 release_note:
-  0.1.0: Initial release of HGVS input
+  1.0.0: Initial release of HGVS input

--- a/converters/hgvs-converter/hgvs-converter.yml
+++ b/converters/hgvs-converter/hgvs-converter.yml
@@ -1,0 +1,13 @@
+title: HGVS Converter
+version: 0.1.0
+type: converter
+description: File converter for HGVS string input
+developer:
+  name: Kyle Anderson
+  organization: Potomac IT Group
+  email: kanderson@potomacitgroup.com
+  website: https://potomacitgroup.com/
+  citation: ''
+requires_opencravat: '>=1.8.0'
+release_note:
+  0.1.0: Alpha release of HGVS input

--- a/converters/hgvs-converter/test/input
+++ b/converters/hgvs-converter/test/input
@@ -1,0 +1,9 @@
+chr22	30025797	+	A	T	sample_1	Tag1
+chr22	30025797	+	A	T	sample_2	TagSame
+chr22	40418496	-	A	G	sample_1	Tag2;Tag2b
+chr22	40419252	+	C	T	sample_1	Tag3
+chr22	24719483	+	-	AGG	sample_2	Tag4
+chr22	24719483	+	AGA	-	sample_2	Tag5
+chr22	24719483	+	AG	T	sample_2	Tag6
+chr2	218270043	+	G	-	sample_3	Tag7
+chr2	218270044	+	-	G	sample_3	Tag8

--- a/converters/hgvs-converter/test/input
+++ b/converters/hgvs-converter/test/input
@@ -1,9 +1,15 @@
-chr22	30025797	+	A	T	sample_1	Tag1
-chr22	30025797	+	A	T	sample_2	TagSame
-chr22	40418496	-	A	G	sample_1	Tag2;Tag2b
-chr22	40419252	+	C	T	sample_1	Tag3
-chr22	24719483	+	-	AGG	sample_2	Tag4
-chr22	24719483	+	AGA	-	sample_2	Tag5
-chr22	24719483	+	AG	T	sample_2	Tag6
-chr2	218270043	+	G	-	sample_3	Tag7
-chr2	218270044	+	-	G	sample_3	Tag8
+NM_004006.2:c.4375C>T   s0  tag
+ENST00000536005.7:c.145C>T  s1  ensembl,bean1
+NM_177402.5:c.1197C>T   s0  more,tags
+
+# NC_000023.10:g.32407761G>A (Feb.2009: h19, GRCh37)
+# NC_000023.11:g.32389644G>A (Dec.2013: hg38, GRCh38)
+# NG_012232.1:g.954966C>T
+# NM_004006.2:c.4375C>T
+# NR_002196.1:n.601G>T
+
+# These three fail
+# CM000678.2:g.66469721C>T
+# ENST00000380152.8:c.-199A>C
+# LRG_199:g.954966C>T
+#chr2	218270044	+	-	G	sample_3	Tag8

--- a/converters/hgvs-converter/test/input
+++ b/converters/hgvs-converter/test/input
@@ -1,15 +1,8 @@
+## HGVS input format
+# One HGVS string per line
+# Optional tab-separated values for sample and tags, sample MUST come first and tags second.
+# Comment lines must start with a # symbol
+
 NM_004006.2:c.4375C>T   s0  tag
 ENST00000536005.7:c.145C>T  s1  ensembl,bean1
 NM_177402.5:c.1197C>T   s0  more,tags
-
-# NC_000023.10:g.32407761G>A (Feb.2009: h19, GRCh37)
-# NC_000023.11:g.32389644G>A (Dec.2013: hg38, GRCh38)
-# NG_012232.1:g.954966C>T
-# NM_004006.2:c.4375C>T
-# NR_002196.1:n.601G>T
-
-# These three fail
-# CM000678.2:g.66469721C>T
-# ENST00000380152.8:c.-199A>C
-# LRG_199:g.954966C>T
-#chr2	218270044	+	-	G	sample_3	Tag8

--- a/converters/hgvs-converter/test/key
+++ b/converters/hgvs-converter/test/key
@@ -1,0 +1,60 @@
+#CRAVAT Report
+#Created at Wednesday 07/22/2020 15:38:22
+#Report level: variant
+#
+Variant Annotation															
+UID	Chrom	Position	Ref Base	Alt Base	Note	Coding	Gene	Transcript	Sequence Ontology	cDNA change	Protein Change	All Mappings	Sample Count	Samples	Tags
+1	chr22	30025797	A	T		Yes	MTMR3	ENST00000401950.6	missense_variant	c.3593A>T	p.Asn1198Ile	ENST00000323630.9:MTMR3::missense_variant:p.Asn1062Ile:c.3185A>T; ENST00000333027.7:MTMR3:Q13615:missense_variant:p.Asn1170Ile:c.3509A>T; ENST00000351488.7:MTMR3:Q13615:missense_variant:p.Asn1161Ile:c.3482A>T; ENST00000401950.6:MTMR3:Q13615:missense_variant:p.Asn1198Ile:c.3593A>T; ENST00000406629.1:MTMR3:Q13615:missense_variant:p.Asn1170Ile:c.3509A>T; ENST00000429350.5:HORMAD2-AS1::intron_variant,lnc_RNA::; ENST00000453743.6:HORMAD2-AS1::intron_variant,lnc_RNA::; ENST00000624945.1:AC003681.1::lnc_RNA::	2	sample_1;sample_2	Tag1;TagSame
+2	chr22	40418496	T	C		Yes	MRTFA	ENST00000355630.9	missense_variant	c.2242A>G	p.Ser748Gly	ENST00000355630.9:MRTFA::missense_variant:p.Ser748Gly:c.2242A>G; ENST00000396617.7:MRTFA::missense_variant:p.Ser648Gly:c.1942A>G; ENST00000402042.6:MRTFA::missense_variant:p.Ser698Gly:c.2092A>G; ENST00000407029.7:MRTFA:Q969V6:missense_variant:p.Ser648Gly:c.1942A>G; ENST00000614754.4:MRTFA::missense_variant:p.Ser649Gly:c.1945A>G; ENST00000618196.6:MRTFA::missense_variant:p.Ser598Gly:c.1792A>G; ENST00000618417.1:MRTFA::intron_variant::c.-1245-5604A>G; ENST00000620651.4:MRTFA::missense_variant:p.Ser599Gly:c.1795A>G; ENST00000651595.1:MRTFA::missense_variant:p.Ser748Gly:c.2242A>G; ENST00000652095.2:MRTFA::missense_variant:p.Ser683Gly:c.2047A>G	1	sample_1	Tag2;Tag2b
+3	chr22	40419252	C	T		Yes	MRTFA	ENST00000355630.9	missense_variant	c.1486G>A	p.Ala496Thr	ENST00000355630.9:MRTFA::missense_variant:p.Ala496Thr:c.1486G>A; ENST00000396617.7:MRTFA::missense_variant:p.Ala396Thr:c.1186G>A; ENST00000402042.6:MRTFA::missense_variant:p.Ala446Thr:c.1336G>A; ENST00000407029.7:MRTFA:Q969V6:missense_variant:p.Ala396Thr:c.1186G>A; ENST00000614754.4:MRTFA::missense_variant:p.Ala397Thr:c.1189G>A; ENST00000618196.6:MRTFA::missense_variant:p.Ala346Thr:c.1036G>A; ENST00000618417.1:MRTFA::intron_variant::c.-1245-6360G>A; ENST00000620651.4:MRTFA::missense_variant:p.Ala347Thr:c.1039G>A; ENST00000651595.1:MRTFA::missense_variant:p.Ala496Thr:c.1486G>A; ENST00000652095.2:MRTFA::missense_variant:p.Ala431Thr:c.1291G>A	1	sample_1	Tag3
+4	chr22	24719483	-	AGG		Yes	PIWIL3	ENST00000332271.9	inframe_insertion	c.2638_2639insCCT	p.Leu879_Phe880insSer	ENST00000332271.9:PIWIL3:Q7Z3Z3:inframe_insertion:p.Leu879_Phe880insSer:c.2638_2639insCCT; ENST00000527701.5:PIWIL3::inframe_insertion:p.Leu761_Phe762insSer:c.2284_2285insCCT; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::inframe_insertion:p.Leu761_Phe762insSer:c.2284_2285insCCT; ENST00000616349.4:PIWIL3:Q7Z3Z3:inframe_insertion:p.Leu879_Phe880insSer:c.2638_2639insCCT	1	sample_2	Tag4
+5	chr22	24719483	AGA	-		Yes	PIWIL3	ENST00000332271.9	inframe_deletion	c.2637_2639del	p.Phe880del	ENST00000332271.9:PIWIL3:Q7Z3Z3:inframe_deletion:p.Phe880del:c.2637_2639del; ENST00000527701.5:PIWIL3::inframe_deletion:p.Phe762del:c.2283_2285del; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::inframe_deletion:p.Phe762del:c.2283_2285del; ENST00000616349.4:PIWIL3:Q7Z3Z3:inframe_deletion:p.Phe880del:c.2637_2639del	1	sample_2	Tag5
+6	chr22	24719483	AG	T		Yes	PIWIL3	ENST00000332271.9	frameshift_truncation	c.2637_2638delinsA	p.Tyr881ThrfsTer9	ENST00000332271.9:PIWIL3:Q7Z3Z3:complex_substitution,frameshift_truncation:p.Tyr881ThrfsTer9:c.2637_2638delinsA; ENST00000527701.5:PIWIL3::complex_substitution,frameshift_truncation:p.Tyr763ThrfsTer9:c.2283_2284delinsA; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::complex_substitution,frameshift_truncation:p.Tyr763ThrfsTer9:c.2283_2284delinsA; ENST00000616349.4:PIWIL3:Q7Z3Z3:complex_substitution,frameshift_truncation:p.Tyr881ThrfsTer9:c.2637_2638delinsA	1	sample_2	Tag6
+7	chr22	24719483	G	T		Yes	PIWIL3	ENST00000332271.9	missense_variant	c.2638C>A	p.Phe880Ile	ENST00000332271.9:PIWIL3:Q7Z3Z3:missense_variant:p.Phe880Ile:c.2638C>A; ENST00000527701.5:PIWIL3::missense_variant:p.Phe762Ile:c.2284C>A; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::missense_variant:p.Phe762Ile:c.2284C>A; ENST00000616349.4:PIWIL3:Q7Z3Z3:missense_variant:p.Phe880Ile:c.2638C>A	1	sample_2	Tagww
+8	chr22	24719484	G	-		Yes	PIWIL3	ENST00000332271.9	frameshift_truncation	c.2637del	p.Tyr881ThrfsTer9	ENST00000332271.9:PIWIL3:Q7Z3Z3:frameshift_truncation:p.Tyr881ThrfsTer9:c.2637del; ENST00000527701.5:PIWIL3::frameshift_truncation:p.Tyr763ThrfsTer9:c.2283del; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::frameshift_truncation:p.Tyr763ThrfsTer9:c.2283del; ENST00000616349.4:PIWIL3:Q7Z3Z3:frameshift_truncation:p.Tyr881ThrfsTer9:c.2637del	1	sample_2	Tagqq
+9	chr2	218270043	G	-		Yes	AAMP	ENST00000248450.8	frameshift_truncation	c.44del	p.Pro15HisfsTer5	ENST00000248450.8:AAMP:Q13685:frameshift_truncation:p.Pro15HisfsTer5:c.44del; ENST00000248451.7:PNKD:Q8N490:2kb_upstream_variant::c.-487del; ENST00000273077.9:PNKD:Q8N490:2kb_upstream_variant::c.-487del; ENST00000420660.5:AAMP::2kb_upstream_variant::c.-445del; ENST00000444053.5:AAMP::frameshift_truncation:p.Pro15HisfsTer5:c.44del; ENST00000472650.1:PNKD::2kb_upstream_variant,processed_transcript::	1	sample_3	Tag7
+10	chr2	218270044	-	G		Yes	AAMP	ENST00000248450.8	frameshift_elongation	c.44dup	p.Leu16ThrfsTer9	ENST00000248450.8:AAMP:Q13685:frameshift_elongation:p.Leu16ThrfsTer9:c.44dup; ENST00000248451.7:PNKD:Q8N490:2kb_upstream_variant::c.-487dup; ENST00000273077.9:PNKD:Q8N490:2kb_upstream_variant::c.-487dup; ENST00000420660.5:AAMP::2kb_upstream_variant::c.-445dup; ENST00000444053.5:AAMP::frameshift_elongation:p.Leu16ThrfsTer9:c.44dup; ENST00000472650.1:PNKD::2kb_upstream_variant,processed_transcript::	1	sample_3	Tag8
+#CRAVAT Report
+#Created at Wednesday 07/22/2020 15:38:22
+#Report level: gene
+#
+Variant Annotation					
+Gene	Note	Number of Coding Variants	Number of Noncoding Variants	Sequence Ontology	All Sequence Ontologies
+MTMR3		1	0	missense_variant	missense_variant(2)
+MRTFA		2	0	missense_variant	intron_variant(2),missense_variant(2)
+PIWIL3		5	0	frameshift_truncation	complex_substitution(1),frameshift_truncation(2),inframe_deletion(1),inframe_insertion(1),missense_variant(1),processed_transcript(5)
+AAMP		2	0	frameshift_elongation	frameshift_truncation(1),frameshift_elongation(1)
+#CRAVAT Report
+#Created at Wednesday 07/22/2020 15:38:22
+#Report level: sample
+#
+Variant Annotation	
+UID	Sample
+1	sample_1
+1	sample_2
+2	sample_1
+3	sample_1
+4	sample_2
+5	sample_2
+6	sample_2
+7	sample_2
+8	sample_2
+9	sample_3
+10	sample_3
+#CRAVAT Report
+#Created at Wednesday 07/22/2020 15:38:22
+#Report level: mapping
+#
+Variant Annotation			
+Original Line	User Tags	UID	Input File Number
+1	Tag1	1	0
+2	TagSame	1	0
+3	Tag2;Tag2b	2	0
+4	Tag3	3	0
+5	Tag4	4	0
+6	Tag5	5	0
+7	Tag6	6	0
+8	Tagww	7	0
+9	Tagqq	8	0
+10	Tag7	9	0
+11	Tag8	10	0

--- a/converters/hgvs-converter/test/key
+++ b/converters/hgvs-converter/test/key
@@ -1,5 +1,5 @@
 #CRAVAT Report
-#Created at Tuesday 03/19/2024 15:16:05
+#Created at Tuesday 03/19/2024 15:53:40
 #Report level: variant
 #
 Variant Annotation																		Original Input			
@@ -8,7 +8,7 @@ UID	Chrom	Position	Ref Base	Alt Base	Variant Note	Coding	Gene	Transcript	Sequenc
 2	chr16	66469721	C	T		Yes	BEAN1	ENST00000536005.7	missense_variant	3	c.145C>T	p.Leu49Phe	ENST00000299694.12:BEAN1:Q3B7T3:5_prime_UTR_variant::c.-183C>T; ENST00000536005.7:BEAN1:Q3B7T3:missense_variant:p.Leu49Phe:c.145C>T; ENST00000561796.5:BEAN1:Q3B7T3:5_prime_UTR_variant::c.-183C>T; ENST00000562849.6:BEAN1:Q3B7T3:NMD_transcript_variant,5_prime_UTR_variant::c.-183C>T; ENST00000563075.1:BEAN1::processed_transcript::; ENST00000564618.1:BEAN1-AS1::2kb_downstream_variant,lnc_RNA::; ENST00000564819.5:BEAN1::5_prime_UTR_variant::c.-183C>T; ENST00000567528.5:BEAN1-AS1::2kb_downstream_variant,lnc_RNA::; ENST00000569125.1:BEAN1-AS1::2kb_downstream_variant,lnc_RNA::; ENST00000622872.4:BEAN1:Q3B7T3:5_prime_UTR_variant::c.-183C>T	66469721	1	s1	ensembl,bean1	chr16	66469721	C	T
 3	chr1	202596820	G	A		Yes	SYT2	ENST00000367268.5	synonymous_variant	9	c.1197C>T	p.Ile399=	ENST00000367267.5:SYT2:Q8N9I0:synonymous_variant:p.Ile399=:c.1197C>T; ENST00000367268.5:SYT2:Q8N9I0:synonymous_variant:p.Ile399=:c.1197C>T	202596820	1	s0	more,tags	chr1	202596820	G	A
 #CRAVAT Report
-#Created at Tuesday 03/19/2024 15:16:05
+#Created at Tuesday 03/19/2024 15:53:40
 #Report level: gene
 #
 Variant Annotation					
@@ -17,7 +17,7 @@ DMD		1	0	stop_gained	intron_variant(1),processed_transcript(1),stop_gained(1)
 BEAN1		1	0	missense_variant	missense_variant(1),NMD_transcript_variant(1),processed_transcript(1),5_prime_UTR_variant(1)
 SYT2		1	0	synonymous_variant	synonymous_variant(1)
 #CRAVAT Report
-#Created at Tuesday 03/19/2024 15:16:05
+#Created at Tuesday 03/19/2024 15:53:40
 #Report level: sample
 #
 Variant Annotation	
@@ -26,11 +26,11 @@ UID	Sample
 2	s1
 3	s0
 #CRAVAT Report
-#Created at Tuesday 03/19/2024 15:16:05
+#Created at Tuesday 03/19/2024 15:53:40
 #Report level: mapping
 #
 Variant Annotation			
 Original Line	User Tags	UID	Input File Number
-1	tag	1	0
-2	ensembl,bean1	2	0
-3	more,tags	3	0
+6	tag	1	0
+7	ensembl,bean1	2	0
+8	more,tags	3	0

--- a/converters/hgvs-converter/test/key
+++ b/converters/hgvs-converter/test/key
@@ -1,60 +1,36 @@
 #CRAVAT Report
-#Created at Wednesday 07/22/2020 15:38:22
+#Created at Tuesday 03/19/2024 15:16:05
 #Report level: variant
 #
-Variant Annotation															
-UID	Chrom	Position	Ref Base	Alt Base	Note	Coding	Gene	Transcript	Sequence Ontology	cDNA change	Protein Change	All Mappings	Sample Count	Samples	Tags
-1	chr22	30025797	A	T		Yes	MTMR3	ENST00000401950.6	missense_variant	c.3593A>T	p.Asn1198Ile	ENST00000323630.9:MTMR3::missense_variant:p.Asn1062Ile:c.3185A>T; ENST00000333027.7:MTMR3:Q13615:missense_variant:p.Asn1170Ile:c.3509A>T; ENST00000351488.7:MTMR3:Q13615:missense_variant:p.Asn1161Ile:c.3482A>T; ENST00000401950.6:MTMR3:Q13615:missense_variant:p.Asn1198Ile:c.3593A>T; ENST00000406629.1:MTMR3:Q13615:missense_variant:p.Asn1170Ile:c.3509A>T; ENST00000429350.5:HORMAD2-AS1::intron_variant,lnc_RNA::; ENST00000453743.6:HORMAD2-AS1::intron_variant,lnc_RNA::; ENST00000624945.1:AC003681.1::lnc_RNA::	2	sample_1;sample_2	Tag1;TagSame
-2	chr22	40418496	T	C		Yes	MRTFA	ENST00000355630.9	missense_variant	c.2242A>G	p.Ser748Gly	ENST00000355630.9:MRTFA::missense_variant:p.Ser748Gly:c.2242A>G; ENST00000396617.7:MRTFA::missense_variant:p.Ser648Gly:c.1942A>G; ENST00000402042.6:MRTFA::missense_variant:p.Ser698Gly:c.2092A>G; ENST00000407029.7:MRTFA:Q969V6:missense_variant:p.Ser648Gly:c.1942A>G; ENST00000614754.4:MRTFA::missense_variant:p.Ser649Gly:c.1945A>G; ENST00000618196.6:MRTFA::missense_variant:p.Ser598Gly:c.1792A>G; ENST00000618417.1:MRTFA::intron_variant::c.-1245-5604A>G; ENST00000620651.4:MRTFA::missense_variant:p.Ser599Gly:c.1795A>G; ENST00000651595.1:MRTFA::missense_variant:p.Ser748Gly:c.2242A>G; ENST00000652095.2:MRTFA::missense_variant:p.Ser683Gly:c.2047A>G	1	sample_1	Tag2;Tag2b
-3	chr22	40419252	C	T		Yes	MRTFA	ENST00000355630.9	missense_variant	c.1486G>A	p.Ala496Thr	ENST00000355630.9:MRTFA::missense_variant:p.Ala496Thr:c.1486G>A; ENST00000396617.7:MRTFA::missense_variant:p.Ala396Thr:c.1186G>A; ENST00000402042.6:MRTFA::missense_variant:p.Ala446Thr:c.1336G>A; ENST00000407029.7:MRTFA:Q969V6:missense_variant:p.Ala396Thr:c.1186G>A; ENST00000614754.4:MRTFA::missense_variant:p.Ala397Thr:c.1189G>A; ENST00000618196.6:MRTFA::missense_variant:p.Ala346Thr:c.1036G>A; ENST00000618417.1:MRTFA::intron_variant::c.-1245-6360G>A; ENST00000620651.4:MRTFA::missense_variant:p.Ala347Thr:c.1039G>A; ENST00000651595.1:MRTFA::missense_variant:p.Ala496Thr:c.1486G>A; ENST00000652095.2:MRTFA::missense_variant:p.Ala431Thr:c.1291G>A	1	sample_1	Tag3
-4	chr22	24719483	-	AGG		Yes	PIWIL3	ENST00000332271.9	inframe_insertion	c.2638_2639insCCT	p.Leu879_Phe880insSer	ENST00000332271.9:PIWIL3:Q7Z3Z3:inframe_insertion:p.Leu879_Phe880insSer:c.2638_2639insCCT; ENST00000527701.5:PIWIL3::inframe_insertion:p.Leu761_Phe762insSer:c.2284_2285insCCT; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::inframe_insertion:p.Leu761_Phe762insSer:c.2284_2285insCCT; ENST00000616349.4:PIWIL3:Q7Z3Z3:inframe_insertion:p.Leu879_Phe880insSer:c.2638_2639insCCT	1	sample_2	Tag4
-5	chr22	24719483	AGA	-		Yes	PIWIL3	ENST00000332271.9	inframe_deletion	c.2637_2639del	p.Phe880del	ENST00000332271.9:PIWIL3:Q7Z3Z3:inframe_deletion:p.Phe880del:c.2637_2639del; ENST00000527701.5:PIWIL3::inframe_deletion:p.Phe762del:c.2283_2285del; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::inframe_deletion:p.Phe762del:c.2283_2285del; ENST00000616349.4:PIWIL3:Q7Z3Z3:inframe_deletion:p.Phe880del:c.2637_2639del	1	sample_2	Tag5
-6	chr22	24719483	AG	T		Yes	PIWIL3	ENST00000332271.9	frameshift_truncation	c.2637_2638delinsA	p.Tyr881ThrfsTer9	ENST00000332271.9:PIWIL3:Q7Z3Z3:complex_substitution,frameshift_truncation:p.Tyr881ThrfsTer9:c.2637_2638delinsA; ENST00000527701.5:PIWIL3::complex_substitution,frameshift_truncation:p.Tyr763ThrfsTer9:c.2283_2284delinsA; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::complex_substitution,frameshift_truncation:p.Tyr763ThrfsTer9:c.2283_2284delinsA; ENST00000616349.4:PIWIL3:Q7Z3Z3:complex_substitution,frameshift_truncation:p.Tyr881ThrfsTer9:c.2637_2638delinsA	1	sample_2	Tag6
-7	chr22	24719483	G	T		Yes	PIWIL3	ENST00000332271.9	missense_variant	c.2638C>A	p.Phe880Ile	ENST00000332271.9:PIWIL3:Q7Z3Z3:missense_variant:p.Phe880Ile:c.2638C>A; ENST00000527701.5:PIWIL3::missense_variant:p.Phe762Ile:c.2284C>A; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::missense_variant:p.Phe762Ile:c.2284C>A; ENST00000616349.4:PIWIL3:Q7Z3Z3:missense_variant:p.Phe880Ile:c.2638C>A	1	sample_2	Tagww
-8	chr22	24719484	G	-		Yes	PIWIL3	ENST00000332271.9	frameshift_truncation	c.2637del	p.Tyr881ThrfsTer9	ENST00000332271.9:PIWIL3:Q7Z3Z3:frameshift_truncation:p.Tyr881ThrfsTer9:c.2637del; ENST00000527701.5:PIWIL3::frameshift_truncation:p.Tyr763ThrfsTer9:c.2283del; ENST00000532537.2:PIWIL3::processed_transcript::; ENST00000533313.5:PIWIL3::frameshift_truncation:p.Tyr763ThrfsTer9:c.2283del; ENST00000616349.4:PIWIL3:Q7Z3Z3:frameshift_truncation:p.Tyr881ThrfsTer9:c.2637del	1	sample_2	Tagqq
-9	chr2	218270043	G	-		Yes	AAMP	ENST00000248450.8	frameshift_truncation	c.44del	p.Pro15HisfsTer5	ENST00000248450.8:AAMP:Q13685:frameshift_truncation:p.Pro15HisfsTer5:c.44del; ENST00000248451.7:PNKD:Q8N490:2kb_upstream_variant::c.-487del; ENST00000273077.9:PNKD:Q8N490:2kb_upstream_variant::c.-487del; ENST00000420660.5:AAMP::2kb_upstream_variant::c.-445del; ENST00000444053.5:AAMP::frameshift_truncation:p.Pro15HisfsTer5:c.44del; ENST00000472650.1:PNKD::2kb_upstream_variant,processed_transcript::	1	sample_3	Tag7
-10	chr2	218270044	-	G		Yes	AAMP	ENST00000248450.8	frameshift_elongation	c.44dup	p.Leu16ThrfsTer9	ENST00000248450.8:AAMP:Q13685:frameshift_elongation:p.Leu16ThrfsTer9:c.44dup; ENST00000248451.7:PNKD:Q8N490:2kb_upstream_variant::c.-487dup; ENST00000273077.9:PNKD:Q8N490:2kb_upstream_variant::c.-487dup; ENST00000420660.5:AAMP::2kb_upstream_variant::c.-445dup; ENST00000444053.5:AAMP::frameshift_elongation:p.Leu16ThrfsTer9:c.44dup; ENST00000472650.1:PNKD::2kb_upstream_variant,processed_transcript::	1	sample_3	Tag8
+Variant Annotation																		Original Input			
+UID	Chrom	Position	Ref Base	Alt Base	Variant Note	Coding	Gene	Transcript	Sequence Ontology	Exon Number	cDNA change	Protein Change	All Mappings	End Position	Sample Count	Samples	Tags	Chrom	Pos	Reference allele	Alternate allele
+1	chrX	32389644	G	A		Yes	DMD	ENST00000357033.8	stop_gained	32	c.4375C>T	p.Arg1459Ter	ENST00000357033.8:DMD::stop_gained:p.Arg1459Ter:c.4375C>T; ENST00000378677.6:DMD::stop_gained:p.Arg1455Ter:c.4363C>T; ENST00000488902.5:DMD::intron_variant,processed_transcript::; ENST00000619831.4:DMD::stop_gained:p.Arg1455Ter:c.4363C>T; ENST00000620040.4:DMD::stop_gained:p.Arg1459Ter:c.4375C>T	32389644	1	s0	tag	chrX	32389644	G	A
+2	chr16	66469721	C	T		Yes	BEAN1	ENST00000536005.7	missense_variant	3	c.145C>T	p.Leu49Phe	ENST00000299694.12:BEAN1:Q3B7T3:5_prime_UTR_variant::c.-183C>T; ENST00000536005.7:BEAN1:Q3B7T3:missense_variant:p.Leu49Phe:c.145C>T; ENST00000561796.5:BEAN1:Q3B7T3:5_prime_UTR_variant::c.-183C>T; ENST00000562849.6:BEAN1:Q3B7T3:NMD_transcript_variant,5_prime_UTR_variant::c.-183C>T; ENST00000563075.1:BEAN1::processed_transcript::; ENST00000564618.1:BEAN1-AS1::2kb_downstream_variant,lnc_RNA::; ENST00000564819.5:BEAN1::5_prime_UTR_variant::c.-183C>T; ENST00000567528.5:BEAN1-AS1::2kb_downstream_variant,lnc_RNA::; ENST00000569125.1:BEAN1-AS1::2kb_downstream_variant,lnc_RNA::; ENST00000622872.4:BEAN1:Q3B7T3:5_prime_UTR_variant::c.-183C>T	66469721	1	s1	ensembl,bean1	chr16	66469721	C	T
+3	chr1	202596820	G	A		Yes	SYT2	ENST00000367268.5	synonymous_variant	9	c.1197C>T	p.Ile399=	ENST00000367267.5:SYT2:Q8N9I0:synonymous_variant:p.Ile399=:c.1197C>T; ENST00000367268.5:SYT2:Q8N9I0:synonymous_variant:p.Ile399=:c.1197C>T	202596820	1	s0	more,tags	chr1	202596820	G	A
 #CRAVAT Report
-#Created at Wednesday 07/22/2020 15:38:22
+#Created at Tuesday 03/19/2024 15:16:05
 #Report level: gene
 #
 Variant Annotation					
-Gene	Note	Number of Coding Variants	Number of Noncoding Variants	Sequence Ontology	All Sequence Ontologies
-MTMR3		1	0	missense_variant	missense_variant(2)
-MRTFA		2	0	missense_variant	intron_variant(2),missense_variant(2)
-PIWIL3		5	0	frameshift_truncation	complex_substitution(1),frameshift_truncation(2),inframe_deletion(1),inframe_insertion(1),missense_variant(1),processed_transcript(5)
-AAMP		2	0	frameshift_elongation	frameshift_truncation(1),frameshift_elongation(1)
+Gene	Gene Note	Number of Coding Variants	Number of Noncoding Variants	Sequence Ontology	All Sequence Ontologies
+DMD		1	0	stop_gained	intron_variant(1),processed_transcript(1),stop_gained(1)
+BEAN1		1	0	missense_variant	missense_variant(1),NMD_transcript_variant(1),processed_transcript(1),5_prime_UTR_variant(1)
+SYT2		1	0	synonymous_variant	synonymous_variant(1)
 #CRAVAT Report
-#Created at Wednesday 07/22/2020 15:38:22
+#Created at Tuesday 03/19/2024 15:16:05
 #Report level: sample
 #
 Variant Annotation	
 UID	Sample
-1	sample_1
-1	sample_2
-2	sample_1
-3	sample_1
-4	sample_2
-5	sample_2
-6	sample_2
-7	sample_2
-8	sample_2
-9	sample_3
-10	sample_3
+1	s0
+2	s1
+3	s0
 #CRAVAT Report
-#Created at Wednesday 07/22/2020 15:38:22
+#Created at Tuesday 03/19/2024 15:16:05
 #Report level: mapping
 #
 Variant Annotation			
 Original Line	User Tags	UID	Input File Number
-1	Tag1	1	0
-2	TagSame	1	0
-3	Tag2;Tag2b	2	0
-4	Tag3	3	0
-5	Tag4	4	0
-6	Tag5	5	0
-7	Tag6	6	0
-8	Tagww	7	0
-9	Tagqq	8	0
-10	Tag7	9	0
-11	Tag8	10	0
+1	tag	1	0
+2	ensembl,bean1	2	0
+3	more,tags	3	0


### PR DESCRIPTION
Input file converter for HGVS inputs.

The expected file format is a plain text file with one HGVS string per line. Optionally, it can accept tab-separated values with additional columns for sample name and tags.

This converter uses a proxy API hosted by OpenCravat to convert the HGVS string to genomic coordinates. The proxy API uses the [BioCommons HGVS](https://github.com/biocommons/hgvs) package with a [SACGF cdot](https://github.com/SACGF/cdot) data provider to determine the coordinates. We determined that the HGVS package installation was more intensive than we wanted for a normal install of OpenCravat, so the proxy API was a compromise to include the necessary features without requiring the user to install HGVS on their system. The cdot data provider was chosen because it had a much more complete and up-to-date database of reference sequences for translation. The code for the proxy API can be found at the [OpenCravat Extras / HGVS-API repository.](https://github.com/KarchinLab/open-cravat-extras/tree/main/hgvs-api)