### PR TITLE
Remove unused `imp` imports in webapps

### DIFF
--- a/webapps/moleculartumorboard/moleculartumorboard.yml
+++ b/webapps/moleculartumorboard/moleculartumorboard.yml
@@ -1,5 +1,5 @@
 title: Molecular Tumor Board Variant Report
-version: 1.2.5
+version: 1.2.6
 type: webapp
 live_modules:
 - cancer_genome_interpreter
@@ -60,6 +60,7 @@ developer:
   website: http://www.insilico.us.com
   citation: ''
 release_note:
+  1.2.6: remove imp module for use with python 3.12
   1.2.5: temporarily disable cosmic hallmarks query
   1.2.4: fixed a bug with hg19 coordinate
   1.1.0: design revamp

--- a/webapps/moleculartumorboard/route.py
+++ b/webapps/moleculartumorboard/route.py
@@ -6,7 +6,6 @@ import urllib.parse
 import json
 import sys
 import argparse
-import imp
 import yaml
 import re
 from cravat import ConfigLoader

--- a/webapps/variantreport/route.py
+++ b/webapps/variantreport/route.py
@@ -6,7 +6,6 @@ import urllib.parse
 import json
 import sys
 import argparse
-import imp
 import yaml
 import re
 from cravat import ConfigLoader

--- a/webapps/variantreport/variantreport.yml
+++ b/webapps/variantreport/variantreport.yml
@@ -1,5 +1,5 @@
 title: OpenCRAVAT Variant Report
-version: 1.3.0
+version: 1.3.1
 type: webapp
 live_modules:
 - aloft
@@ -184,6 +184,7 @@ developer:
   website: 
   citation: ''
 release_note:
+  1.3.1: remove imp module for use with python 3.12
   1.3.0: updated variant effect predictions panel
   1.2.2: works with updated phylop and phastcons
   1.2.1: show documentation on blank page

--- a/webapps/variantreport/widgets/wglollipop2/wglollipop2.js
+++ b/webapps/variantreport/widgets/wglollipop2/wglollipop2.js
@@ -173,7 +173,7 @@ widgetGenerators['lollipop2'] = {
                     addEl(div, spinner);
                     if (hugo != v.hugo) {
                         $.ajax({
-                            url: '/webapps/moleculartumorboard/widgets/' + widgetName, 
+                            url: '/webapps/variantreport/widgets/' + widgetName,
                             data: {hugo: hugo},
                             success: function (data) {
                                 v['data'] = data;


### PR DESCRIPTION
* Also fix url in the variantreport wglollipop2 javascript that was querying the moleculartumorboard webapp rather than the variantreport one