### PR TITLE
OC-506 ESM1b and Varity_R calibration

### DIFF
--- a/annotators/esm1b/esm1b.md
+++ b/annotators/esm1b/esm1b.md
@@ -8,3 +8,21 @@ Each variant’s effect score is the log-likelihood ratio (LLR) between the vari
 To assess the performance of ESM1b in predicting the clinical impact of variants, the model’s effect scores between pathogenic and benign variants annotated in ClinVar and variants annotated by HGMD as disease-causing and benign variants from gnomAD (defined by allele frequency >1%) were compared. Only high-confidence variants were included. The distribution of ESM1b effect scores shows a substantial difference between pathogenic and benign variants in both datasets. Using an LLR threshold of −7.5 to distinguish between pathogenic and benign variants yields a true-positive rate of 81% and a true-negative rate of 82% in both datasets.
 
 Information from https://doi.org/10.1038/s41588-023-01465-0
+
+## Clinical Application
+
+ The ClinGen Sequence Variant Interpretation Working Group reccommends that calibrated scores from select variant effect predictors are reliable as Very Strong, Strong, or Moderate evidence for Pathogenicity (PP3) or Benignity (BP4) within ACMG/AMP Guidelines (Pejaver, Vikas et al. “Calibration of computational tools for missense variant pathogenicity classification and ClinGen recommendations for PP3/BP4 criteria.” American journal of human genetics vol. 109,12 (2022): 2163-2177. doi:10.1016/j.ajhg.2022.10.013).
+
+ESM1b scores have been calbrated and validated as reliable to support Benign Supporting, Benign Moderate, Benign Strong, Benign Very Strong, Pathogenic Supporting, Pathogenic Moderate, and Pathogenic Strong ACMG/AMP evidence for purposes of variant classification in the clinic. Calibration cutoffs were obtained from Bergquist et al., “Calibration of Additional Computational Tools Expands ClinGen Recommendation Options for Variant Classification with PP3/BP4 Criteria.” bioRxiv 2024.09.17.611902; doi:10.1101/2024.09.17.611902
+
+ | ESM1b Thresholds |      |             |              |                  |                |                |        |
+ |------------------|------|-------------|--------------|------------------|----------------|----------------|--------|
+ | Benign (BP4)     |      |             |              | Pathogenic (PP3) |                |                |        |
+ | Strong           | Firm | Moderate    | Supporting   | Supporting       | Moderate       | Firm           | Strong |
+ | -                | >8.7 | (-3.2, 8.7] | (-6.2, -3.2] | (-12.2, -10.7]   | [-12.2, -14.0) | (-24.0, -14.0] | ≤-24.0 |
+
+ \* A "-" means that ESM1b did not meet the posterior probability threshold. Note that "(" and ")" indicate exclusion of the end value and “[” and “]” indicate inclusion of the end value.
+
+ ### Indeterminate Scores
+
+ If the ESM1b score does not fit within the thresholds above, Benign (BP4) and Pathogenic (PP3) columns are left blank and described as "Indeterminate" in the corresponding ESM1b widget.

--- a/annotators/esm1b/esm1b.md
+++ b/annotators/esm1b/esm1b.md
@@ -15,11 +15,12 @@ Information from https://doi.org/10.1038/s41588-023-01465-0
 
 ESM1b scores have been calbrated and validated as reliable to support Benign Supporting, Benign Moderate, Benign Strong, Benign Very Strong, Pathogenic Supporting, Pathogenic Moderate, and Pathogenic Strong ACMG/AMP evidence for purposes of variant classification in the clinic. Calibration cutoffs were obtained from Bergquist et al., “Calibration of Additional Computational Tools Expands ClinGen Recommendation Options for Variant Classification with PP3/BP4 Criteria.” bioRxiv 2024.09.17.611902; doi:10.1101/2024.09.17.611902
 
- | ESM1b Thresholds |      |             |              |                  |                |                |        |
- |------------------|------|-------------|--------------|------------------|----------------|----------------|--------|
- | Benign (BP4)     |      |             |              | Pathogenic (PP3) |                |                |        |
- | Strong           | Firm | Moderate    | Supporting   | Supporting       | Moderate       | Firm           | Strong |
- | -                | >8.7 | (-3.2, 8.7] | (-6.2, -3.2] | (-12.2, -10.7]   | [-12.2, -14.0) | (-24.0, -14.0] | ≤-24.0 |
+ | ESM1b Thresholds |        |          |              |                  |                |        |             |
+ |------------------|--------|----------|--------------|------------------|----------------|--------|-------------|
+ | Benign (BP4)     |        |          |              | Pathogenic (PP3) |                |        |             |
+ | Very Strong      | Strong | Moderate | Supporting   | Supporting       | Moderate       | Strong | Very Strong |
+ | -                | -      | >-3.2    | (-6.2, -3.2] | (-12.2, -10.7]   | [-12.2, -24.0) | ≤-24.0 | -           |
+
 
  \* A "-" means that ESM1b did not meet the posterior probability threshold. Note that "(" and ")" indicate exclusion of the end value and “[” and “]” indicate inclusion of the end value.
 

--- a/annotators/esm1b/esm1b.py
+++ b/annotators/esm1b/esm1b.py
@@ -21,28 +21,19 @@ def get_bin(score, cutoffs):
         if prev_cutoff is not None and prev_cutoff > cutoff:
             raise ValueError("cutoffs are not sorted")
         prev_cutoff = cutoff
-    return labels[-1]  ## when we run out of cutoffs
     
 
-PATHOGENICITY_CUTOFFS = [
-    (-24.0, "PP3 Strong"),
-    (-14.0, "PP3 Firm"),
-    (-12.2, "PP3 Moderate"),
-    (-10.7, "PP3 Supporting"),
-    (-6.2, "Indeterminate"),
-    (-3.2, "BP4 Supporting"),
-    (8.7, "BP4 Moderate"),
-    (float("inf"), "BP4 Firm"),
+PP3_CUTOFFS = [
+    (-24.0, "Strong"),
+    (-12.2, "Moderate"),
+    (-10.7, "Supporting"),
+    (float("inf"), "")
 ]
-PATHOGENICITY_CUTOFFS = [
-    (-24.0, "PP3 Strong (+4 Pathogenic)"),
-    (-14.0, "PP3 [Firm] (+3 Pathogenic) "),
-    (-12.2, "PP3 Moderate (+2 Pathogenic)"),
-    (-10.7, "PP3 Supporting (+1 Pathogenic)"),
-    (-6.2, "Indeterminate (0)"),
-    (-3.2, "BP4 Supporting (-1 Benign)"),
-    (8.7, "BP4 Moderate (-2 Benign)"),
-    (float("inf"), "BP4 [Firm] (-3 Benign)"),
+
+BP4_CUTOFFS = [
+    (-6.3, ""),
+    (-3.1, "Supporting"),
+    (float("inf"), "Moderate"),
 ]
 
 class CravatAnnotator(BaseAnnotator):
@@ -80,8 +71,8 @@ class CravatAnnotator(BaseAnnotator):
                         'rankscore': rankscore,
                         'prediction': prediction,
                         'full_result' : transc_revel_result,
-                        'benign': benign,
-                        'pathogenicity': get_bin(score, PATHOGENICITY_CUTOFFS)
+                        'benign': get_bin(score, BP4_CUTOFFS),
+                        'pathogenic': get_bin(score, PP3_CUTOFFS)
                     })
             if precomp_data:
                 all_transcripts = set()
@@ -95,7 +86,8 @@ class CravatAnnotator(BaseAnnotator):
                     if x['score'] == min_score:
                         all_transcripts.add(x['transcript'])
                         all_predictions.add(x['prediction'])
-                        pathogenicity = x['pathogenicity']
+                        benign = x['benign']
+                        pathogenic = x['benign']
                 all_transcripts = list(all_transcripts)
                 all_transcripts = ';'.join(all_transcripts)
                 all_predictions = list(all_predictions )
@@ -106,9 +98,10 @@ class CravatAnnotator(BaseAnnotator):
                 return {
                     'transcript': all_transcripts,
                     'score': min_score,
-                    'pathogenicity': pathogenicity,
                     'rankscore': rankscore,
                     'prediction': all_predictions,
+                    'benign': benign,
+                    'pathogenic': pathogenic,
                     'all': all_results_list
                 }
 

--- a/annotators/esm1b/esm1b.py
+++ b/annotators/esm1b/esm1b.py
@@ -71,8 +71,8 @@ class CravatAnnotator(BaseAnnotator):
                         'rankscore': rankscore,
                         'prediction': prediction,
                         'full_result' : transc_revel_result,
-                        'benign': get_bin(score, BP4_CUTOFFS),
-                        'pathogenic': get_bin(score, PP3_CUTOFFS)
+                        'bp4_benign': get_bin(score, BP4_CUTOFFS),
+                        'pp3_pathogenic': get_bin(score, PP3_CUTOFFS)
                     })
             if precomp_data:
                 all_transcripts = set()
@@ -86,8 +86,8 @@ class CravatAnnotator(BaseAnnotator):
                     if x['score'] == min_score:
                         all_transcripts.add(x['transcript'])
                         all_predictions.add(x['prediction'])
-                        benign = x['benign']
-                        pathogenic = x['benign']
+                        benign = x['bp4_benign']
+                        pathogenic = x['pp3_pathogenic']
                 all_transcripts = list(all_transcripts)
                 all_transcripts = ';'.join(all_transcripts)
                 all_predictions = list(all_predictions )
@@ -100,8 +100,8 @@ class CravatAnnotator(BaseAnnotator):
                     'score': min_score,
                     'rankscore': rankscore,
                     'prediction': all_predictions,
-                    'benign': benign,
-                    'pathogenic': pathogenic,
+                    'bp4_benign': benign,
+                    'pp3_pathogenic': pathogenic,
                     'all': all_results_list
                 }
 

--- a/annotators/esm1b/esm1b.py
+++ b/annotators/esm1b/esm1b.py
@@ -4,6 +4,47 @@ from cravat import InvalidData
 import sqlite3
 import os
 
+
+def get_bin(score, cutoffs):
+    """Locate the location of `score` in a list[tuple(float, str)] of
+    `cutoffs`, where the float cutoff is the maximum value, inclusive
+    of the value, for that label. The last tuple should typically have
+    `float("inf")` as the cutoff, otherwise the function may retun
+    `None`
+
+    The cutoffs must be sorted in increasing value.
+    """
+    prev_cutoff = None
+    for cutoff, label in cutoffs:
+        if score <= cutoff:
+            return label
+        if prev_cutoff is not None and prev_cutoff > cutoff:
+            raise ValueError("cutoffs are not sorted")
+        prev_cutoff = cutoff
+    return labels[-1]  ## when we run out of cutoffs
+    
+
+PATHOGENICITY_CUTOFFS = [
+    (-24.0, "PP3 Strong"),
+    (-14.0, "PP3 Firm"),
+    (-12.2, "PP3 Moderate"),
+    (-10.7, "PP3 Supporting"),
+    (-6.2, "Indeterminate"),
+    (-3.2, "BP4 Supporting"),
+    (8.7, "BP4 Moderate"),
+    (float("inf"), "BP4 Firm"),
+]
+PATHOGENICITY_CUTOFFS = [
+    (-24.0, "PP3 Strong (+4 Pathogenic)"),
+    (-14.0, "PP3 [Firm] (+3 Pathogenic) "),
+    (-12.2, "PP3 Moderate (+2 Pathogenic)"),
+    (-10.7, "PP3 Supporting (+1 Pathogenic)"),
+    (-6.2, "Indeterminate (0)"),
+    (-3.2, "BP4 Supporting (-1 Benign)"),
+    (8.7, "BP4 Moderate (-2 Benign)"),
+    (float("inf"), "BP4 [Firm] (-3 Benign)"),
+]
+
 class CravatAnnotator(BaseAnnotator):
     def annotate(self, input_data, secondary_data=None):
         out = None
@@ -29,11 +70,23 @@ class CravatAnnotator(BaseAnnotator):
                         prediction = "Tolerated"
                     elif predictions[i] == "D":
                         prediction = "Deleterious"
+                    else:
+                        prediction = ""
+                    
                     transc_revel_result = [transc, score, rankscore, prediction]
-                    precomp_data.append({'transcript':transc, 'score': score, 'rankscore': rankscore, 'prediction': prediction, 'full_result' : transc_revel_result})
+                    precomp_data.append({
+                        'transcript':transc,
+                        'score': score,
+                        'rankscore': rankscore,
+                        'prediction': prediction,
+                        'full_result' : transc_revel_result,
+                        'benign': benign,
+                        'pathogenicity': get_bin(score, PATHOGENICITY_CUTOFFS)
+                    })
             if precomp_data:
                 all_transcripts = set()
                 all_predictions = set()
+                pathogenicity = ""
                 scores = [x['score'] for x in precomp_data]
                 all_results_list = [x['full_result'] for x in precomp_data]
                 # min score is used because the smaller the score the more pathogenic it is.
@@ -42,6 +95,7 @@ class CravatAnnotator(BaseAnnotator):
                     if x['score'] == min_score:
                         all_transcripts.add(x['transcript'])
                         all_predictions.add(x['prediction'])
+                        pathogenicity = x['pathogenicity']
                 all_transcripts = list(all_transcripts)
                 all_transcripts = ';'.join(all_transcripts)
                 all_predictions = list(all_predictions )
@@ -49,8 +103,14 @@ class CravatAnnotator(BaseAnnotator):
                 min_index = scores.index(min_score)
                 best_mapping = precomp_data[min_index]
                 rankscore = best_mapping['rankscore']
-                out = {'transcript': all_transcripts, 'score': min_score, 'rankscore': rankscore, 'prediction': all_predictions, 'all': all_results_list}
-                return out
+                return {
+                    'transcript': all_transcripts,
+                    'score': min_score,
+                    'pathogenicity': pathogenicity,
+                    'rankscore': rankscore,
+                    'prediction': all_predictions,
+                    'all': all_results_list
+                }
 
         
 if __name__ == '__main__':

--- a/annotators/esm1b/esm1b.yml
+++ b/annotators/esm1b/esm1b.yml
@@ -34,7 +34,7 @@ output_columns:
   hidden: false
   width: 80
   desc: The variant is predicted as either "Tolerated" or "Deleterious" based on the threshold of -7.5 described in their paper that yields a true-positive rate of 81% and a true-negative rate of 82% in their ClinVar and HGMD test datasets.
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -42,7 +42,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/esm1b/esm1b.yml
+++ b/annotators/esm1b/esm1b.yml
@@ -23,14 +23,6 @@ output_columns:
   type: float
   desc: Scores are log-likelihood ratio (LLR) scores for predicting the pathogenic effects of coding variants. The scores range from from -24.538 to 6.937. The smaller the score, the more likely the variant is pathogenic. 
   hidden: true
-- name: pathogenic
-  title: ACMG/AMP Pathogenicity (BP4/PP3)
-  type: string
-  hidden: false
-  width: 110
-  desc: Strength of evidence for pathogenicity or benignity.
-  category: multi
-  filterable: true
 - name: rankscore
   title: Rank Score
   type: float
@@ -42,6 +34,22 @@ output_columns:
   hidden: false
   width: 80
   desc: The variant is predicted as either "Tolerated" or "Deleterious" based on the threshold of -7.5 described in their paper that yields a true-positive rate of 81% and a true-negative rate of 82% in their ClinVar and HGMD test datasets.
+- name: benign
+  title: ACMG/AMP Benign (BP4)
+  type: string
+  hidden: false
+  category: multi
+  filterable: true
+  width: 100
+  desc: Strength of evidence for benignity.
+- name: pathogenic
+  title: ACMG/AMP Pathogenic (PP3)
+  type: string
+  hidden: false
+  width: 110
+  desc: Strength of evidence for pathogenicity.
+  category: multi
+  filterable: true
 - hidden: true
   name: all
   title: All Annotations

--- a/annotators/esm1b/esm1b.yml
+++ b/annotators/esm1b/esm1b.yml
@@ -1,5 +1,5 @@
 title: ESM1b
-version: 1.0.1
+version: 1.1.0
 datasource: dbNSFP v4.7a
 type: annotator
 description: ESM1b is a 650-million-parameter protein language model to predict all ~450 million possible missense variant effects in the human genome.
@@ -23,6 +23,14 @@ output_columns:
   type: float
   desc: Scores are log-likelihood ratio (LLR) scores for predicting the pathogenic effects of coding variants. The scores range from from -24.538 to 6.937. The smaller the score, the more likely the variant is pathogenic. 
   hidden: true
+- name: pathogenic
+  title: ACMG/AMP Pathogenicity (BP4/PP3)
+  type: string
+  hidden: false
+  width: 110
+  desc: Strength of evidence for pathogenicity or benignity.
+  category: multi
+  filterable: true
 - name: rankscore
   title: Rank Score
   type: float
@@ -61,6 +69,7 @@ tags:
 - variant effect prediction
 - variants
 release_note:
+  1.1.0: pathogenicity calibration
   1.0.1: updated column descriptions
   1.0.0: initial release
 

--- a/annotators/varity_r/varity_r.md
+++ b/annotators/varity_r/varity_r.md
@@ -13,15 +13,15 @@ The VARITY approach for pathogenicity prediction, which has been specifically op
 
 VARITY scores have been calbrated and validated as reliable to support Benign Supporting, Benign Moderate, Benign Strong, Benign Very Strong, Pathogenic Supporting, Pathogenic Moderate, and Pathogenic Strong ACMG/AMP evidence for purposes of variant classification in the clinic. Calibration cutoffs were obtained from Bergquist et al., “Calibration of Additional Computational Tools Expands ClinGen Recommendation Options for Variant Classification with PP3/BP4 Criteria.” bioRxiv 2024.09.17.611902; doi:10.1101/2024.09.17.611902
 
- | ESM1b Thresholds |                |                |                 |                  |                |                |         |
- |------------------|----------------|----------------|-----------------|------------------|----------------|----------------|---------|
- | Benign (BP4)     |                |                |                 | Pathogenic (PP3) |                |                |         |
- | Strong           | Firm           | Moderate       | Supporting      | Supporting       | Moderate       | Firm           | Strong  |
- | ≤0.036           | (0.036, 0.063] | (0.063, 0.116] | (0.0116, 0.251] | (0.675, 0.841]   | (0.841, 0.914] | (0.914, 0.964] | > 0.965 |
+ | ESM1b Thresholds |        |                |                 |                  |                |         |             |
+ |------------------|--------|----------------|-----------------|------------------|----------------|---------|-------------|
+ | Benign (BP4)     |        |                |                 | Pathogenic (PP3) |                |         |             |
+ | Very Strong      | Strong | Moderate       | Supporting      | Supporting       | Moderate       | Strong  | Very Strong |
+ | -                | ≤0.036 | (0.036, 0.116] | (0.0116, 0.251] | (0.675, 0.841]   | (0.841, 0.964] | >0.964 | -           |
 
 
  \* A "-" means that Varity did not meet the posterior probability threshold. Note that "(" and ")" indicate exclusion of the end value and “[” and “]” indicate inclusion of the end value.
 
- ### Indeterminate Scores
+### Indeterminate Scores
 
  If the Varity score does not fit within the thresholds above, Benign (BP4) and Pathogenic (PP3) columns are left blank and described as "Indeterminate" in the corresponding Varity widget.

--- a/annotators/varity_r/varity_r.md
+++ b/annotators/varity_r/varity_r.md
@@ -5,3 +5,23 @@ The success of personalized genomic medicine depends on our ability to assess th
 The VARITY approach for pathogenicity prediction, which has been specifically optimized for rare missense variation. While VARITY uses a meta-prediction strategy, it limits the circularity that can arise in such approaches by excluding any feature that was informed by variant pathogenicity annotation. We also exclude features that may serve as proxies for protein identity because these may lead to predictions that are biased by the fraction of each protein’s variants in the training set that are annotated pathogenic (which may be inaccurate in future application settings). VARITY judiciously harnesses a larger set of training examples with uncertain accuracy and representativity and uses differential weighting strategies to ensure that training set expansion improves performance on a high-quality test set.
 
 ![The VARITY framework](fig_01.jpg)
+
+## Clinical Application
+
+ The ClinGen Sequence Variant Interpretation Working Group reccommends that calibrated scores from select variant effect predictors are reliable as Very Strong, Strong, or Moderate evidence for Pathogenicity (PP3) or Benignity (BP4) within ACMG/AMP Guidelines (Pejaver, Vikas et al. “Calibration of computational tools for missense variant pathogenicity classification and ClinGen recommendations for PP3/BP4 criteria.” American journal of human genetics vol. 109,12 (2022): 2163-2177. doi:10.1016/j.ajhg.2022.10.013).
+
+
+VARITY scores have been calbrated and validated as reliable to support Benign Supporting, Benign Moderate, Benign Strong, Benign Very Strong, Pathogenic Supporting, Pathogenic Moderate, and Pathogenic Strong ACMG/AMP evidence for purposes of variant classification in the clinic. Calibration cutoffs were obtained from Bergquist et al., “Calibration of Additional Computational Tools Expands ClinGen Recommendation Options for Variant Classification with PP3/BP4 Criteria.” bioRxiv 2024.09.17.611902; doi:10.1101/2024.09.17.611902
+
+ | ESM1b Thresholds |                |                |                 |                  |                |                |         |
+ |------------------|----------------|----------------|-----------------|------------------|----------------|----------------|---------|
+ | Benign (BP4)     |                |                |                 | Pathogenic (PP3) |                |                |         |
+ | Strong           | Firm           | Moderate       | Supporting      | Supporting       | Moderate       | Firm           | Strong  |
+ | ≤0.036           | (0.036, 0.063] | (0.063, 0.116] | (0.0116, 0.251] | (0.675, 0.841]   | (0.841, 0.914] | (0.914, 0.964] | > 0.965 |
+
+
+ \* A "-" means that Varity did not meet the posterior probability threshold. Note that "(" and ")" indicate exclusion of the end value and “[” and “]” indicate inclusion of the end value.
+
+ ### Indeterminate Scores
+
+ If the Varity score does not fit within the thresholds above, Benign (BP4) and Pathogenic (PP3) columns are left blank and described as "Indeterminate" in the corresponding Varity widget.

--- a/annotators/varity_r/varity_r.py
+++ b/annotators/varity_r/varity_r.py
@@ -24,17 +24,17 @@ def get_bin(score, cutoffs):
 
 
 BP4_CUTOFFS = [
-    (0.036, 'BP4 Strong (-4 Benign)'),
-    (0.116, 'BP4 Moderate (-2 Benign)'),
-    (0.251, 'BP4 Supporting (-1 Benign)'),
+    (0.036, 'Strong'),
+    (0.116, 'Moderate '),
+    (0.251, 'Supporting'),
     (float("inf"), '')
 ]
 
 PP3_CUTOFFS = [
     (0.675, ''),
-    (0.841, 'PP3 Supporting (+1 Pathogenic)'),
-    (0.964, 'PP3 Moderate (+2 Pathogenic)'),
-    (float("inf"), 'PP3 Strong (+4 Pathogenic)')
+    (0.841, 'Supporting'),
+    (0.964, 'Moderate'),
+    (float("inf"), 'Strong')
 ]
 
 class CravatAnnotator(BaseAnnotator):
@@ -52,11 +52,12 @@ class CravatAnnotator(BaseAnnotator):
         )
         row = self.cursor.fetchone()
         if row is not None:
+            varity_r = float(row[1])
             return {
                 'p_vid': row[0],
-                'varity_r': row[1],
-                'varity_r_benign': get_bin(row[1], BP4_CUTOFFS),
-                'varity_r_pathogenic': get_bin(row[1], PP3_CUTOFFS),
+                'varity_r': varity_r,
+                'bp4_benign': get_bin(varity_r, BP4_CUTOFFS),
+                'pp3_pathogenic': get_bin(varity_r, PP3_CUTOFFS),
                 'varity_er': row[2],
                 'varity_r_loo': row[3],
                 'varity_er_loo': row[4],

--- a/annotators/varity_r/varity_r.py
+++ b/annotators/varity_r/varity_r.py
@@ -21,18 +21,19 @@ def get_bin(score, cutoffs):
         if prev_cutoff is not None and prev_cutoff > cutoff:
             raise ValueError("cutoffs are not sorted")
         prev_cutoff = cutoff
-    return labels[-1]  ## when we run out of cutoffs
 
 
-PATHOGENICITY_CUTOFFS = [
+BP4_CUTOFFS = [
     (0.036, 'BP4 Strong (-4 Benign)'),
-    (0.063, 'BP4 [Firm] (-3 Benign)'),
     (0.116, 'BP4 Moderate (-2 Benign)'),
     (0.251, 'BP4 Supporting (-1 Benign)'),
-    (0.675, 'Indeterminate (0)'),
+    (float("inf"), '')
+]
+
+PP3_CUTOFFS = [
+    (0.675, ''),
     (0.841, 'PP3 Supporting (+1 Pathogenic)'),
-    (0.914, 'PP3 Moderate (+2 Pathogenic)'),
-    (0.964, 'PP3 [Firm] (+3 Pathogenic) '),
+    (0.964, 'PP3 Moderate (+2 Pathogenic)'),
     (float("inf"), 'PP3 Strong (+4 Pathogenic)')
 ]
 
@@ -54,7 +55,8 @@ class CravatAnnotator(BaseAnnotator):
             return {
                 'p_vid': row[0],
                 'varity_r': row[1],
-                'varity_r_pathogenicity': get_bin(row[1], PATHOGENICITY_CUTOFFS),
+                'varity_r_benign': get_bin(row[1], BP4_CUTOFFS),
+                'varity_r_pathogenic': get_bin(row[1], PP3_CUTOFFS),
                 'varity_er': row[2],
                 'varity_r_loo': row[3],
                 'varity_er_loo': row[4],

--- a/annotators/varity_r/varity_r.py
+++ b/annotators/varity_r/varity_r.py
@@ -4,6 +4,38 @@ from cravat import InvalidData
 import sqlite3
 import os
 
+
+def get_bin(score, cutoffs):
+    """Locate the location of `score` in a list[tuple(float, str)] of
+    `cutoffs`, where the float cutoff is the maximum value, inclusive
+    of the value, for that label. The last tuple should typically have
+    `float("inf")` as the cutoff, otherwise the function may retun
+    `None`
+
+    The cutoffs must be sorted in increasing value.
+    """
+    prev_cutoff = None
+    for cutoff, label in cutoffs:
+        if score <= cutoff:
+            return label
+        if prev_cutoff is not None and prev_cutoff > cutoff:
+            raise ValueError("cutoffs are not sorted")
+        prev_cutoff = cutoff
+    return labels[-1]  ## when we run out of cutoffs
+
+
+PATHOGENICITY_CUTOFFS = [
+    (0.036, 'BP4 Strong (-4 Benign)'),
+    (0.063, 'BP4 [Firm] (-3 Benign)'),
+    (0.116, 'BP4 Moderate (-2 Benign)'),
+    (0.251, 'BP4 Supporting (-1 Benign)'),
+    (0.675, 'Indeterminate (0)'),
+    (0.841, 'PP3 Supporting (+1 Pathogenic)'),
+    (0.914, 'PP3 Moderate (+2 Pathogenic)'),
+    (0.964, 'PP3 [Firm] (+3 Pathogenic) '),
+    (float("inf"), 'PP3 Strong (+4 Pathogenic)')
+]
+
 class CravatAnnotator(BaseAnnotator):
 
     def setup(self): 
@@ -22,6 +54,7 @@ class CravatAnnotator(BaseAnnotator):
             return {
                 'p_vid': row[0],
                 'varity_r': row[1],
+                'varity_r_pathogenicity': get_bin(row[1], PATHOGENICITY_CUTOFFS),
                 'varity_er': row[2],
                 'varity_r_loo': row[3],
                 'varity_er_loo': row[4],

--- a/annotators/varity_r/varity_r.yml
+++ b/annotators/varity_r/varity_r.yml
@@ -9,6 +9,14 @@ output_columns:
   type: float
   desc: VARITY_R score
   width: 72
+- name: pathogenic
+  title: ACMG/AMP Pathogenicity (BP4/PP3)
+  type: string
+  hidden: false
+  width: 72
+  desc: Strength of evidence for pathogenicity or benignity ofr VARITY_R score
+  category: multi
+  filterable: true
 - name: varity_er
   title: VARITY_ER
   type: float

--- a/annotators/varity_r/varity_r.yml
+++ b/annotators/varity_r/varity_r.yml
@@ -9,12 +9,20 @@ output_columns:
   type: float
   desc: VARITY_R score
   width: 72
-- name: pathogenic
-  title: ACMG/AMP Pathogenicity (BP4/PP3)
+- name: varity_r_benign
+  title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
-  width: 72
-  desc: Strength of evidence for pathogenicity or benignity ofr VARITY_R score
+  category: multi
+  filterable: true
+  width: 100
+  desc: Strength of evidence for benignity.
+- name: varity_r_pathogenic
+  title: ACMG/AMP Pathogenic (PP3)
+  type: string
+  hidden: false
+  width: 110
+  desc: Strength of evidence for pathogenicity.
   category: multi
   filterable: true
 - name: varity_er

--- a/annotators/varity_r/varity_r.yml
+++ b/annotators/varity_r/varity_r.yml
@@ -9,7 +9,7 @@ output_columns:
   type: float
   desc: VARITY_R score
   width: 72
-- name: varity_r_benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -17,7 +17,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: varity_r_pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/webviewerwidgets/wgesm1b/wgesm1b.js
+++ b/webviewerwidgets/wgesm1b/wgesm1b.js
@@ -14,16 +14,18 @@ widgetGenerators['esm1b'] = {
 			if (allMappings != undefined && allMappings != null) {
                 var results = JSON.parse(allMappings);
 				var table = getWidgetTableFrame();
-				var thead = getWidgetTableHead(['Transcript', 'Score', 'Rank score', 'Prediction']);
+				// TODO: cvaske should check with kylem about how these are ordered... most likely by YML?
+				var thead = getWidgetTableHead(['Transcript', 'Score', 'Pathogenicity', 'Rank score', 'Prediction']);
 				addEl(table, thead);
 				var tbody = getEl('tbody');
                 for (var i = 0; i < results.length; i++) {
 					var row = results[i];
 					var transcript = row[0];
 					var score = row[1];
-					var rankscore = row[2];
-                    var pred = row[3]
-					var tr = getWidgetTableTr([transcript, score, rankscore, pred]);
+					var pathogenicity = row[2];
+					var rankscore = row[3];
+                    var pred = row[4]
+					var tr = getWidgetTableTr([transcript, score, pathogenicity, rankscore, pred]);
 					addEl(tbody, tr);
 				}
 				addEl(div, addEl(table, tbody));

--- a/webviewerwidgets/wgesm1b/wgesm1b.js
+++ b/webviewerwidgets/wgesm1b/wgesm1b.js
@@ -14,18 +14,28 @@ widgetGenerators['esm1b'] = {
 			if (allMappings != undefined && allMappings != null) {
                 var results = JSON.parse(allMappings);
 				var table = getWidgetTableFrame();
-				// TODO: cvaske should check with kylem about how these are ordered... most likely by YML?
-				var thead = getWidgetTableHead(['Transcript', 'Score', 'Pathogenicity', 'Rank score', 'Prediction']);
+				// TODO: cvaske should check with kylem about how a row is ordered... most likely by YML? This code is a stab in the dark...
+				var thead = getWidgetTableHead(['Transcript', 'Score', 'Rank score', 'Prediction', 'Pathogenicity']);
 				addEl(table, thead);
 				var tbody = getEl('tbody');
                 for (var i = 0; i < results.length; i++) {
 					var row = results[i];
 					var transcript = row[0];
 					var score = row[1];
-					var pathogenicity = row[2];
-					var rankscore = row[3];
-                    var pred = row[4]
-					var tr = getWidgetTableTr([transcript, score, pathogenicity, rankscore, pred]);
+					var rankscore = row[2];
+                    var pred = row[3]
+					var bp4 = row[4];
+					var pp3 = row[5]
+					var pathogenicity = "Indeterminate";
+					if (bp4 != null) {
+						pathogenicity = "BP4 " + bp4
+					} else if(pp3 !== null) {
+						pathogenicity = "PP3 " + pp3
+					}
+					var tr = getWidgetTableTr([transcript, score, rankscore, pred, pathogenicity]);
+					$(tr).children().eq(4).css("background-color", color);
+					$(tr).children().eq(4).css("color", pathogenicity.includes("Strong") ? "white" : "black");
+
 					addEl(tbody, tr);
 				}
 				addEl(div, addEl(table, tbody));

--- a/webviewerwidgets/wgesm1b/wgesm1b.yml
+++ b/webviewerwidgets/wgesm1b/wgesm1b.yml
@@ -1,5 +1,5 @@
 title: ESM1b
-version: 1.0.0
+version: 1.1.0
 type: webviewerwidget
 required_annotator: esm1b
 description: esm1b webviewer widget
@@ -12,3 +12,5 @@ developer:
 tags:
 - visualization
 requires_opencravat: '>=2.2.1'
+release_note:
+  1.1.0: display pathogenicity calibration


### PR DESCRIPTION
Questions:

- How should this be tested? @kylemoad 
- Reporting style needs to be vetted by others. I adopted the FATHMM style of a single `pathogenicity` category but a lot of the other calibrations instead create two new columns, one for pathogenic and one for benign
- Label text for pathogenicity should be vetted by a second person, possibly discussed as a group.