### PR TITLE
Add PhyloP and and Gerp++ to 'variant effect prediction'

### DIFF
--- a/annotators/gerp/gerp.yml
+++ b/annotators/gerp/gerp.yml
@@ -38,6 +38,7 @@ output_columns:
   width: 100
   desc: Strength of evidence for benignity.
 tags:
+- variant effect prediction
 - variants
 - evolution
 - clinical relevance

--- a/annotators/phylop/phylop.yml
+++ b/annotators/phylop/phylop.yml
@@ -73,6 +73,7 @@ output_columns:
   filterable: true
 tags:
 - variants
+- variant effect prediction
 - evolution
 - clinical revelance
 title: PhyloP


### PR DESCRIPTION
As discussed at status meeting, it may be appropriate for PhyloP and GERP++ to be in the variant effect prediction category, especially since they are now calibrated.