### PR TITLE
split FATHMM pathogenicity into BP4/PP3

### DIFF
--- a/annotators/fathmm/fathmm.md
+++ b/annotators/fathmm/fathmm.md
@@ -15,11 +15,11 @@ The ClinGen Sequence Variant Interpretation Working Group reccommends that calib
 
 FATHMM scores have been calbrated and validated as reliable to support Benign Supporting, Benign Moderate, Pathogenic Supporting, and Pathogenic Moderate ACMG/AMP evidence for purposes of variant classification in the clinic.
 
-| FATHMM Thresholds |                 |                |                |                |                |                |                |                |
-|--------------|-----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|
-| Benign (BP4) |||| Pathogenic (PP3)|
-|Very Strong   |Strong      |Moderate     |Supporting   |Supporting   |Moderate     |Strong      |Very Strong   |
-|-|-|	≥4.69|	[3.32, 4.69)|	(−5.04, −4.14]|	≤ −5.04|-|   -   |
+| FATHMM Thresholds |        |          |              |                  |          |        |             |   |
+|-------------------|--------|----------|--------------|------------------|----------|--------|-------------|---|
+| Benign (BP4)      |        |          |              | Pathogenic (PP3) |          |        |             |   |
+| Very Strong       | Strong | Moderate | Supporting   | Supporting       | Moderate | Strong | Very Strong |   |
+| -                 | -      | ≥4.69    | [3.32, 4.69) | (−5.04, −4.14]   | ≤ −5.04  | -      | -           |   |
 
 \* A "-" means that FATHMM did not meet the posterior probability threshold. Note that "(" and ")" indicate exclusion of the end value and “[” and “]” indicate inclusion of the end value.
 

--- a/annotators/fathmm/fathmm.py
+++ b/annotators/fathmm/fathmm.py
@@ -25,26 +25,33 @@ class CravatAnnotator(BaseAnnotator):
         self.curs.execute(stmt)
         row = self.curs.fetchone()
         if row is not None:
-            pathogenicity_list = []
+            pathogenic_list = []
+            benign_list = []
             scores = row[2].split(";")
             for val in scores:
                 score = float(val)
                 if score >= 4.69:
-                    pathogenicity_list.append("BP4 Moderate")
+                    pathogenic_list.append("")
+                    benign_list.append("Moderate")
                 elif score >= 3.32 and score < 4.69:
-                    pathogenicity_list.append("BP4 Supporting")
+                    pathogenic_list.append("")
+                    benign_list.append("Supporting")
                 elif score > -5.04 and score >= -4.14:
-                    pathogenicity_list.append("PP3 Supporting")
+                    pathogenic_list.append("Supporting")
+                    benign_list.append("")
                 elif score <= -5.04:
-                    pathogenicity_list.append("PP3 Moderate")
+                    pathogenic_list.append("Moderate")
+                    benign_list.append("")
                 else:
-                    pathogenicity_list.append("Indeterminate")
+                    pathogenic_list.append("")
+                    benign_list.append("")
             out['ens_tid'] = row[0]
             out['ens_pid'] = row[1]
             out['fathmm_score'] = row[2]
             out['fathmm_rscore'] = float(row[3])
             out['fathmm_pred'] = row[4]
-            out['fathmm_pathogenicity'] = ';'.join(pathogenicity_list)
+            out['fathmm_benign'] = ';'.join(benign_list)
+            out['fathmm_pathogenic'] = ';'.join(pathogenic_list)
         return out
     
     def cleanup(self):

--- a/annotators/fathmm/fathmm.py
+++ b/annotators/fathmm/fathmm.py
@@ -50,8 +50,8 @@ class CravatAnnotator(BaseAnnotator):
             out['fathmm_score'] = row[2]
             out['fathmm_rscore'] = float(row[3])
             out['fathmm_pred'] = row[4]
-            out['fathmm_benign'] = ';'.join(benign_list)
-            out['fathmm_pathogenic'] = ';'.join(pathogenic_list)
+            out['bp4_benign'] = ';'.join(benign_list)
+            out['pp3_pathogenic'] = ';'.join(pathogenic_list)
         return out
     
     def cleanup(self):

--- a/annotators/fathmm/fathmm.yml
+++ b/annotators/fathmm/fathmm.yml
@@ -42,7 +42,7 @@ output_columns:
   type: string
   filterable: false
   width: 68
-- name: fathmm_benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -50,7 +50,7 @@ output_columns:
   desc: Strength of evidence for benignity.
   category: multi
   filterable: true
-- name: fathmm_pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenicity (PP3)
   type: string
   hidden: false

--- a/annotators/fathmm/fathmm.yml
+++ b/annotators/fathmm/fathmm.yml
@@ -42,12 +42,20 @@ output_columns:
   type: string
   filterable: false
   width: 68
-- name: fathmm_pathogenicity
-  title: ACMG/AMP Pathogenicity
+- name: fathmm_benign
+  title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
   width: 110
-  desc: Strength of evidence for benignity or pathogenicity.
+  desc: Strength of evidence for benignity.
+  category: multi
+  filterable: true
+- name: fathmm_pathogenic
+  title: ACMG/AMP Pathogenicity (PP3)
+  type: string
+  hidden: false
+  width: 110
+  desc: Strength of evidence for pathogenicity.
   category: multi
   filterable: true
 tags:
@@ -64,3 +72,4 @@ release_note:
   2.3.7: non-canonical chrom support for older oc versions
   2.3.6: handle only specific alt chroms
 
+  

--- a/webviewerwidgets/wgfathmm/wgfathmm.js
+++ b/webviewerwidgets/wgfathmm/wgfathmm.js
@@ -18,8 +18,10 @@ widgetGenerators['fathmm'] = {
 			var pidls = pid != null ? pid.split(';') : [];
 			var score = getWidgetData(tabName, 'fathmm', row, 'fathmm_score');
 			var scorels = score != null ? score.split(';') : [];
-			var pathogenicity = getWidgetData(tabName, 'fathmm', row, 'fathmm_pathogenicity');
-			var pathogenicityls = pathogenicity != null ? pathogenicity.split(';') : [];
+			var pathogenic = getWidgetData(tabName, 'fathmm', row, 'fathmm_pathogenic');
+			var pathogenicls = pathogenic != null ? pathogenic.split(';') : [];
+			var benign = getWidgetData(tabName, 'fathmm', row, 'fathmm_benign');
+			var benignls = benign != null ? benign.split(';') : [];
 			for (var i=0;i<scorels.length;i++){
 				if (scorels[i] == '.'){
 					scorels[i] = null;
@@ -43,7 +45,16 @@ widgetGenerators['fathmm'] = {
 				var piditr = pidls[i];
 				var sitr = scorels[i];
 				var pitr = predls[i];
-				var pathogenicityr = pathogenicityls[i]
+				var bp4 = benignls[i]
+				var pp3 = pathogenicls[i]
+				let pathogenicityr = null
+				if (bp4 !== null) {
+					pathogenicity = "BP4 " + bp4
+				} else if (pp3 !== null) {
+					pathogenicity = "PP3 " + pp3
+				} else if (pp3 === null && bp4 === null && vert_score !== null) {
+					pathogenicity = "Indeterminate"
+				}
 				var tr = getWidgetTableTr([tiditr, piditr, sitr, pitr, pathogenicityr]);
 				const color = getCalibrationGradientColor(pathogenicityr)
 				if (pathogenicity !== "") {

--- a/webviewerwidgets/wgfathmm/wgfathmm.js
+++ b/webviewerwidgets/wgfathmm/wgfathmm.js
@@ -18,9 +18,9 @@ widgetGenerators['fathmm'] = {
 			var pidls = pid != null ? pid.split(';') : [];
 			var score = getWidgetData(tabName, 'fathmm', row, 'fathmm_score');
 			var scorels = score != null ? score.split(';') : [];
-			var pathogenic = getWidgetData(tabName, 'fathmm', row, 'fathmm_pathogenic');
+			var pathogenic = getWidgetData(tabName, 'fathmm', row, 'bp4_pathogenic');
 			var pathogenicls = pathogenic != null ? pathogenic.split(';') : [];
-			var benign = getWidgetData(tabName, 'fathmm', row, 'fathmm_benign');
+			var benign = getWidgetData(tabName, 'fathmm', row, 'pp3_benign');
 			var benignls = benign != null ? benign.split(';') : [];
 			for (var i=0;i<scorels.length;i++){
 				if (scorels[i] == '.'){
@@ -36,7 +36,7 @@ widgetGenerators['fathmm'] = {
 			}
 			var table = getWidgetTableFrame();
 			addEl(div, table);
-			var thead = getWidgetTableHead(['Transcript', 'Protein', 'Score', 'Prediction', 'ACMG Pathogenicity'],['25%','22%','10%','12%', '30%']);
+			var thead = getWidgetTableHead(['Transcript', 'Protein', 'Score', 'Prediction', 'ACMG/AMP Pathogenicity'],['25%','22%','10%','12%', '30%']);
 			addEl(table, thead);
 			var tbody = getEl('tbody');
 			addEl(table, tbody);


### PR DESCRIPTION
FATHMM, unlike the other calibrated variant effect predictors, currently uses a single reporting column that puts both the BP4 and PP3 into a single result column. However in the reporting widgets, there's a single column for both.

This commit splits the annotator output into two columns, and then rejoins the columns in the web viewer widget, to match the behavior of the other calibrations.

This change still needs to be tested before merging, and is left here for comment.