### PR TITLE
VEP column name changes

### DIFF
--- a/annotators/bayesdel/bayesdel.py
+++ b/annotators/bayesdel/bayesdel.py
@@ -44,8 +44,8 @@ class CravatAnnotator(BaseAnnotator):
                    'bayesdel_noAF_score': no_af_score,
                    'bayesdel_noAF_rankscore': row[4],
                    'bayesdel_noAF_pred': noaf_pred,
-                   'benign': benign,
-                   'pathogenic': pathogenic
+                   'bp4_benign': benign,
+                   'pp3_pathogenic': pathogenic
                    }
         else:
             out = None

--- a/annotators/bayesdel/bayesdel.yml
+++ b/annotators/bayesdel/bayesdel.yml
@@ -12,39 +12,39 @@ developer:
 level: variant
 output_columns:
 - name: bayesdel_addAF_score
-  title: Score (MaxAF)
+  title: Score (AF)
   type: float
   hidden: true
   width: 80
-  desc: MaxAF score includes the background population frequency of the variant. The scores range from -1.11707 to 0.750927.
+  desc: AF score includes the background population frequency of the variant. The scores range from -1.11707 to 0.750927.
 - name: bayesdel_addAF_rankscore
-  title: Rank Score (MaxAF)
+  title: Rank Score (AF)
   type: float
   hidden: true
   width: 100
   desc:  Ratio of the rank of the score over the total number of BayesDel maxAF scores. The score cutoff between Deleterious and Tolerated is 0.0692655, based upon the authors recommendation.
 - name: bayesdel_addAF_pred
-  title: Prediction (MaxAF)
+  title: Prediction (AF)
   type: string
   hidden: true
   width: 90
-  desc: MaxAF prediction includes the background population frequency of the variant.
+  desc: AF prediction includes the background population frequency of the variant.
 - name: bayesdel_noAF_score
-  title: Score (no MaxAF)
+  title: Score (no AF)
   type: float
   width: 70
-  desc: No MaxAF score does not include the background population frequency of the variant. The scores range from -1.31914 to 0.840878.
+  desc: No AF score does not include the background population frequency of the variant. The scores range from -1.31914 to 0.840878.
 - name: bayesdel_noAF_rankscore
-  title: Rank Score (no MaxAF)
+  title: Rank Score (no AF)
   type: float
   width: 90
   desc: Ratio of the rank of the score over the total number of BayesDel no maxAF scores
 - name: bayesdel_noAF_pred
-  title: Prediction (no MaxAF)
+  title: Prediction (no AF)
   type: string
   width: 80
-  desc: No MaxAF prediction does not include the background population frequency of the variant. The score cutoff between Deleterious and Tolerated is -0.0570105, based upon the authors recommendation.
-- name: benign
+  desc: No AF prediction does not include the background population frequency of the variant. The score cutoff between Deleterious and Tolerated is -0.0570105, based upon the authors recommendation.
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -52,7 +52,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity. Based on scores that do not include the background population frequency of the variant
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/cadd/cadd.py
+++ b/annotators/cadd/cadd.py
@@ -40,7 +40,7 @@ class CravatAnnotator(BaseAnnotator):
                 else:
                     benign = ""
                     pathogenic = ""
-                return {'score':record[4], 'phred': phred, 'benign': benign, 'pathogenic': pathogenic}
+                return {'score':record[4], 'phred': phred, 'bp4_benign': benign, 'pp3_pathogenic': pathogenic}
     
     def cleanup(self):
         pass

--- a/annotators/cadd/cadd.yml
+++ b/annotators/cadd/cadd.yml
@@ -16,7 +16,7 @@ output_columns:
     of each variant relative to all possible 8.6 billion substitutions in the human
     reference genome. A scaled score of 10, for example, refers to the top 10% of
     all reference genome SNVs.
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -24,7 +24,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/cadd_exome/cadd_exome.py
+++ b/annotators/cadd_exome/cadd_exome.py
@@ -50,7 +50,7 @@ class CravatAnnotator(BaseAnnotator):
             else:
                 benign = ""
                 pathogenic = ""
-            return {'score': score,'phred': phred, 'benign': benign, 'pathogenic': pathogenic}
+            return {'score': score,'phred': phred, 'bp4_benign': benign, 'pp3_pathogenic': pathogenic}
     
     def cleanup(self):
         pass

--- a/annotators/cadd_exome/cadd_exome.yml
+++ b/annotators/cadd_exome/cadd_exome.yml
@@ -10,7 +10,7 @@ output_columns:
 - name: phred
   title: Phred
   type: float
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -18,7 +18,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/gerp/gerp.py
+++ b/annotators/gerp/gerp.py
@@ -31,7 +31,8 @@ class CravatAnnotator(BaseAnnotator):
             out['gerp_nr'] = self.myCast(row[0])
             out['gerp_rs'] = self.myCast(row[1])
             out['gerp_rs_rank'] = self.myCast(row[2])
-            out['gerp_benign'] = benign
+            out['bp4_benign'] = benign
+            out['bp4_pathogenic'] = ""
             return out
     
     def cleanup(self):

--- a/annotators/gerp/gerp.yml
+++ b/annotators/gerp/gerp.yml
@@ -29,7 +29,7 @@ output_columns:
   width: 60
   filterable: false
   desc: Rank of the score in dbNSFP divided by the total number of scores in dbNSFP
-- name: gerp_benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -37,6 +37,14 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
+- name: pp3_pathogenic
+  title: ACMG/AMP Pathogenic (PP3)
+  type: string
+  hidden: false
+  width: 110
+  desc: Strength of evidence for pathogenicity.
+  category: multi
+  filterable: true
 tags:
 - variants
 - evolution

--- a/annotators/phylop/phylop.py
+++ b/annotators/phylop/phylop.py
@@ -44,8 +44,8 @@ class CravatAnnotator(BaseAnnotator):
             out['phylop470_mamm_r'] = float(row[3])
             out['phylop17_primate'] = float(row[4])
             out['phylop17_primate_r'] = float(row[5])
-            out['benign'] = benign
-            out['pathogenic'] = pathogenic
+            out['bp4_benign'] = benign
+            out['pp3_pathogenic'] = pathogenic
         return out
     
     def cleanup(self):

--- a/annotators/phylop/phylop.yml
+++ b/annotators/phylop/phylop.yml
@@ -55,7 +55,7 @@ output_columns:
   width: 54
   filterable: false
   hidden: false
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -63,7 +63,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity, based upon the 100-way Vertebrate Score.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/primateai/primateai.py
+++ b/annotators/primateai/primateai.py
@@ -30,8 +30,8 @@ class CravatAnnotator(BaseAnnotator):
             out = {'primateai_score': row[0],
                    'primateai_rankscore': row[1], 
                    'primateai_pred': row[2], 
-                   'benign': benign,
-                   'pathogenic': pathogenic
+                   'bp4_benign': benign,
+                   'pp3_pathogenic': pathogenic
                    }
         else:
             out = None

--- a/annotators/primateai/primateai.yml
+++ b/annotators/primateai/primateai.yml
@@ -22,7 +22,7 @@ output_columns:
   hidden: true
   width: 90
   desc: Prediction of PrimateAI score based on the authors' recommendation, "T(olerated)" or "D(amaging)". The score cutoff between "D" and "T" is 0.803.
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -30,7 +30,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp4_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/revel/revel.py
+++ b/annotators/revel/revel.py
@@ -80,7 +80,7 @@ class CravatAnnotator(BaseAnnotator):
                 worst_rankscore = worst_mapping['rankscore']
                 worst_pathogenic = worst_mapping['pathogenic']
                 worst_benign = worst_mapping['benign']
-                out = {'transcript': all_transcripts, 'score': max_score, 'rankscore': worst_rankscore, 'pathogenic': worst_pathogenic, 'benign': worst_benign, 'all': all_results_list}
+                out = {'transcript': all_transcripts, 'score': max_score, 'rankscore': worst_rankscore, 'pp3_pathogenic': worst_pathogenic, 'bp4_benign': worst_benign, 'all': all_results_list}
                 return out
 
         

--- a/annotators/revel/revel.yml
+++ b/annotators/revel/revel.yml
@@ -30,7 +30,7 @@ output_columns:
   hidden: true
   desc: Max rank score across all transcripts. The ratio of the rank of the score
     over the total number of REVEL scores.
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -38,7 +38,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/sift/sift.py
+++ b/annotators/sift/sift.py
@@ -86,8 +86,8 @@ class CravatAnnotator(BaseAnnotator):
                     out['med'] = worst_med
                     out['confidence'] = worst_confidence
                     out['seqs'] = worst_seqs
-                    out['benign'] = worst_benign
-                    out['pathogenic'] = worst_pathogenic
+                    out['bp4_benign'] = worst_benign
+                    out['pp3_pathogenic'] = worst_pathogenic
                     out['all'] = all_results_list
                     out['multsite'] = 'True' if len(all_results_list) > 1 else None
                     return out

--- a/annotators/sift/sift.yml
+++ b/annotators/sift/sift.yml
@@ -56,7 +56,7 @@ output_columns:
     represented at that position, and this column indicates this.
   width: 60
   hidden: true
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -64,7 +64,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/annotators/vest/vest.py
+++ b/annotators/vest/vest.py
@@ -105,8 +105,8 @@ class CravatAnnotator(BaseAnnotator):
                     'transcript': worst_transcript,
                     'score': max_score,
                     'pval': worst_pval,
-                    'pathogenic': worst_pathogenic,
-                    'benign': worst_benign,
+                    'pp3_pathogenic': worst_pathogenic,
+                    'bp4_benign': worst_benign,
                     'all': all_results_list,
                     'hugo': input_data['hugo'],
                 }

--- a/annotators/vest/vest.yml
+++ b/annotators/vest/vest.yml
@@ -68,7 +68,7 @@ output_columns:
   type: float
   filterable: false
   hidden: true
-- name: benign
+- name: bp4_benign
   title: ACMG/AMP Benign (BP4)
   type: string
   hidden: false
@@ -76,7 +76,7 @@ output_columns:
   filterable: true
   width: 100
   desc: Strength of evidence for benignity.
-- name: pathogenic
+- name: pp3_pathogenic
   title: ACMG/AMP Pathogenic (PP3)
   type: string
   hidden: false

--- a/webviewerwidgets/wgbayesdel/wgbayesdel.js
+++ b/webviewerwidgets/wgbayesdel/wgbayesdel.js
@@ -12,11 +12,11 @@ widgetGenerators['bayesdel'] = {
                 return;
 			}
 			var table = getWidgetTableFrame();
-            var thead = getWidgetTableHead(['Score (no MaxAF)', 'Pathogenicity']);
+            var thead = getWidgetTableHead(['Score (no AF)', 'ACMG/AMP Pathogenicity']);
             addEl(table, thead);
             var tbody = getEl('tbody');
-            var bp4 = getWidgetData(tabName, 'bayesdel', row, 'benign');
-            var pp3 = getWidgetData(tabName, 'bayesdel', row, 'pathogenic');
+            var bp4 = getWidgetData(tabName, 'bayesdel', row, 'bp4_benign');
+            var pp3 = getWidgetData(tabName, 'bayesdel', row, 'pp3_pathogenic');
             let pathogenicity 
             if (bp4 !== null) {
                 pathogenicity = "BP4 " + bp4

--- a/webviewerwidgets/wgcadd/wgcadd.js
+++ b/webviewerwidgets/wgcadd/wgcadd.js
@@ -13,11 +13,11 @@ widgetGenerators['cadd'] = {
 			}
 			if (phred != undefined && phred != null) {
                 var table = getWidgetTableFrame();
-                var thead = getWidgetTableHead(['Phred','Pathogenicity']);
+                var thead = getWidgetTableHead(['Phred','ACMG/AMP Pathogenicity']);
                 addEl(table, thead);
                 var tbody = getEl('tbody');
-                var bp4 = getWidgetData(tabName, 'cadd', row, 'benign');
-                var pp3 = getWidgetData(tabName, 'cadd', row, 'pathogenic');
+                var bp4 = getWidgetData(tabName, 'cadd', row, 'bp4_benign');
+                var pp3 = getWidgetData(tabName, 'cadd', row, 'pp3_pathogenic');
                 let pathogenicity 
                 if (bp4 !== null) {
                     pathogenicity = "BP4 " + bp4

--- a/webviewerwidgets/wgcadd_exome/wgcadd_exome.js
+++ b/webviewerwidgets/wgcadd_exome/wgcadd_exome.js
@@ -13,11 +13,11 @@ widgetGenerators['cadd_exome'] = {
 			}
 			if (phred != undefined && phred != null) {
                 var table = getWidgetTableFrame();
-                var thead = getWidgetTableHead(['Phred','Pathogenicity']);
+                var thead = getWidgetTableHead(['Phred','ACMG/AMP Pathogenicity']);
                 addEl(table, thead);
                 var tbody = getEl('tbody');
-                var bp4 = getWidgetData(tabName, 'cadd_exome', row, 'benign');
-                var pp3 = getWidgetData(tabName, 'cadd_exome', row, 'pathogenic');
+                var bp4 = getWidgetData(tabName, 'cadd_exome', row, 'bp4_benign');
+                var pp3 = getWidgetData(tabName, 'cadd_exome', row, 'pp3_pathogenic');
                 let pathogenicity 
                 if (bp4 !== null) {
                     pathogenicity = "BP4 " + bp4

--- a/webviewerwidgets/wggerp/wggerp.js
+++ b/webviewerwidgets/wggerp/wggerp.js
@@ -7,12 +7,12 @@ widgetGenerators['gerp'] = {
 			addInfoLine(div, row, 'Neutral Rate', 'gerp__gerp_nr', tabName);
 			addInfoLine(div, row, 'RS Score', 'gerp__gerp_rs', tabName);
 			addInfoLine(div, row, 'RS Ranked Score', 'gerp__gerp_rs_rank', tabName);
-			var pathogenicity = getWidgetData(tabName, 'gerp', row, 'gerp_benign');
+			var pathogenicity = getWidgetData(tabName, 'gerp', row, 'bp4_benign');
 			var score = getWidgetData(tabName, 'gerp', row, 'gerp_rs');
 			if (pathogenicity === null && score != undefined) {
-				addInfoLineText(div, 'BP4 Pathogenicity', 'Indeterminate')
+				addInfoLineText(div, 'ACMG/AMP Pathogenicity', 'Indeterminate')
 			} else {
-				addInfoLine(div, row, 'BP4 Pathogenicity', 'gerp__gerp_benign', tabName);
+				addInfoLine(div, row, 'ACMG/AMP Pathogenicity', 'gerp__bp4_benign', tabName);
 			}
 		}
 	}

--- a/webviewerwidgets/wgphylop/wgphylop.js
+++ b/webviewerwidgets/wgphylop/wgphylop.js
@@ -11,8 +11,8 @@ widgetGenerators['phylop'] = {
 			addInfoLine(div, 'Mammalian Ranked Score', getWidgetData(tabName, 'phylop', row, 'phylop470_mamm_r'), tabName);
 			addInfoLine(div, 'Primate Score', getWidgetData(tabName, 'phylop', row, 'phylop17_primate'), tabName);
 			addInfoLine(div, 'Primate Ranked Score', getWidgetData(tabName, 'phylop', row, 'phylop17_primate_r'), tabName);
-			var bp4 = getWidgetData(tabName, 'phylop', row, 'benign')
-			var pp3 = getWidgetData(tabName, 'phylop', row, 'pathogenic')
+			var bp4 = getWidgetData(tabName, 'phylop', row, 'bp4_benign')
+			var pp3 = getWidgetData(tabName, 'phylop', row, 'pp3_pathogenic')
 			let pathogenicity = null
 			if (bp4 !== null) {
 				pathogenicity = "BP4 " + bp4
@@ -21,7 +21,7 @@ widgetGenerators['phylop'] = {
 			} else if (pp3 === null && bp4 === null && vert_score !== null) {
 				pathogenicity = "Indeterminate"
 			}
-			addInfoLine(div, 'Primate Ranked Score', pathogenicity);
+			addInfoLine(div, 'ACMG/AMP Pathogenicity', pathogenicity);
 		}
 	}
 }

--- a/webviewerwidgets/wgprimateai/wgprimateai.js
+++ b/webviewerwidgets/wgprimateai/wgprimateai.js
@@ -12,11 +12,11 @@ widgetGenerators['primateai'] = {
                 return;
 			}
             var table = getWidgetTableFrame();
-            var thead = getWidgetTableHead(['Score', 'Pathogenicity']);
+            var thead = getWidgetTableHead(['Score', 'ACMP/AMP Pathogenicity']);
             addEl(table, thead);
             var tbody = getEl('tbody');
-            var bp4 = getWidgetData(tabName, 'primateai', row, 'benign');
-            var pp3 = getWidgetData(tabName, 'primateai', row, 'pathogenic');
+            var bp4 = getWidgetData(tabName, 'primateai', row, 'bp4_benign');
+            var pp3 = getWidgetData(tabName, 'primateai', row, 'pp3_pathogenic');
             let pathogenicity 
             if (bp4 !== null) {
                 pathogenicity = "BP4 " + bp4

--- a/webviewerwidgets/wgrevel/wgrevel.js
+++ b/webviewerwidgets/wgrevel/wgrevel.js
@@ -14,7 +14,7 @@ widgetGenerators['revel'] = {
 			if (allMappings != undefined && allMappings != null) {
                 var results = JSON.parse(allMappings);
 				var table = getWidgetTableFrame();
-				var thead = getWidgetTableHead(['Transcript', 'Score', 'Rank score', 'Pathogenicity']);
+				var thead = getWidgetTableHead(['Transcript', 'Score', 'Rank score', 'ACMG/AMP Pathogenicity']);
 				addEl(table, thead);
 				var tbody = getEl('tbody');
                 for (var i = 0; i < results.length; i++) {

--- a/webviewerwidgets/wgsift/wgsift.js
+++ b/webviewerwidgets/wgsift/wgsift.js
@@ -7,7 +7,7 @@ widgetGenerators['sift'] = {
 			if (allMappings != undefined && allMappings != null) {
                 var results = JSON.parse(allMappings);
 				var table = getWidgetTableFrame();
-				var thead = getWidgetTableHead(['Transcript', 'Prediction', 'Confidence', 'Score', 'Rank Score', 'Median Info', 'Seqs at Position', 'Pathogenicity'],['15%']);
+				var thead = getWidgetTableHead(['Transcript', 'Prediction', 'Confidence', 'Score', 'Rank Score', 'Median Info', 'Seqs at Position', 'ACMG/AMP Pathogenicity'],['15%']);
 				addEl(table, thead);
 				var tbody = getEl('tbody');
                 for (var i = 0; i < results.length; i++) {

--- a/webviewerwidgets/wgvest/wgvest.js
+++ b/webviewerwidgets/wgvest/wgvest.js
@@ -14,7 +14,7 @@ widgetGenerators['vest'] = {
                 }
                 var results = JSON.parse(allMappings);
 				var table = getWidgetTableFrame();
-				var thead = getWidgetTableHead(['Transcript', 'Score', 'Pathogenicity']);
+				var thead = getWidgetTableHead(['Transcript', 'Score', 'ACMG/AMP Pathogenicity']);
 				addEl(table, thead);
 				var tbody = getEl('tbody');
                 for (var i = 0; i < results.length; i++) {
@@ -23,7 +23,7 @@ widgetGenerators['vest'] = {
 					var score = row[1].toFixed(3);
                     var bp4 = row[3]
                     var pp3 = row[4]
-                    let pathogenicity
+                    let pathogenicity = ""
                     if (bp4 !== "") {
 						pathogenicity = "BP4 " + bp4
 					} else if (pp3 !== "") {


### PR DESCRIPTION
This commit addresses the following issues:

* OC-518: standardize to bp4_benign and pp3_pathogenic column names
* OC-519: fix PhyloP widget bug on name of pathogenicity column
* OC-520: standardize widget column name to "ACMG/AMP Pathogenicity"
* OC-521: BayesDel column names should use "AF" and not "MaxAF"

Currently in testing