### PR TITLE
Add error handling for 2k up/down variants

### DIFF
--- a/annotators/clingen_allele_registry/clingen_allele_registry.py
+++ b/annotators/clingen_allele_registry/clingen_allele_registry.py
@@ -15,6 +15,11 @@ class CravatAnnotator(BaseAnnotator):
         alt = input_data['alt_base']
         transcript = input_data.get('transcript')
         cchange = input_data.get('cchange')
+        so = input_data.get('so')
+
+        if '2KD' == so or '2KU' == so or not cchange:
+            return { 'allele_registry_id': '' }
+
         hgvs = f'{transcript}:{cchange}'
         resp = requests.get(f'{ALLELE_REGISTRY_ENDPOINT}{hgvs}')
         resp.raise_for_status()

--- a/annotators/clingen_allele_registry/clingen_allele_registry.yml
+++ b/annotators/clingen_allele_registry/clingen_allele_registry.yml
@@ -36,7 +36,8 @@ tags:
 title: ClinGen Allele Registry
 type: annotator
 requires_opencravat: '>=1.4.0'
-version: 1.1.0
+version: 1.1.1
 release_note:
+  1.1.1: Fix for 2k upstream / downstream variants
   1.1.0: Change data source to call API
   1.0.0: New annotator for the ClinGen Allele Registry


### PR DESCRIPTION
* 2k upstream or downstream variants will fall out of bounds of the selected transcript, which is not allowed for a valid HGVS representation, so we specifically skip those variants.
* Also skip variants where no c-change is mapped