### PR TITLE
Update ClinGen Allele Registry annotator to annotate batches

### DIFF
--- a/annotators/clingen_allele_registry/clingen_allele_registry.py
+++ b/annotators/clingen_allele_registry/clingen_allele_registry.py
@@ -5,37 +5,64 @@ import requests
 from cravat import BaseAnnotator
 
 class CravatAnnotator(BaseAnnotator):
+    def annotate_batch(self, batch):
+        """Annotate a batch of variants
 
-    def annotate(self, input_data, secondary_data=None):
+        Use the ClinGen Allele Registry to API to annotate many variants at once.
+        annotate_batch will be provided with a batch of input lines. This method
+        will create an HGVS string for each variant, then call the batch version
+        of the API. ClinGen Allele Registry recommends 100,000 variants per batch.
+        """
+        hgvs_strings = {}
+        lines_to_skip = []
+
+        # build hgvs strings for each input line
+        for lnum, line, input_data, secondary_data in batch:
+            transcript = input_data.get('transcript')
+            cchange = input_data.get('cchange')
+            so = input_data.get('so')
+            # skip far up/downstream variants
+            if '2KD' == so or '2KU' == so or not cchange:
+                lines_to_skip.append(lnum)
+                continue
+            hgvs_strings[lnum] = f'{transcript}:{cchange}'
+
+        # list hgvs strings to post to allele registry api
+        post_data = '\n'.join(hgvs_strings.values())
         ALLELE_REGISTRY_ENDPOINT = self.conf['api_url']
-        out = {}
-        chrom = input_data['chrom']
-        pos = input_data['pos']
-        ref = input_data['ref_base']
-        alt = input_data['alt_base']
-        transcript = input_data.get('transcript')
-        cchange = input_data.get('cchange')
-        so = input_data.get('so')
+        resp = requests.post(ALLELE_REGISTRY_ENDPOINT, data=post_data)
+        if resp.status_code != 200:
+            self.logger.error(f'Clingen Allele Registry API Error: {resp.status_code}\n{resp.text}')
 
-        if '2KD' == so or '2KU' == so or not cchange:
-            return { 'allele_registry_id': '' }
-
-        hgvs = f'{transcript}:{cchange}'
-        resp = requests.get(f'{ALLELE_REGISTRY_ENDPOINT}{hgvs}')
         resp.raise_for_status()
-        result = resp.json()
+        results = resp.json()
 
-        if result:
-            full_id = result.get('@id')
-            ca_id = str.split(full_id, '/')[-1]
-            if ca_id and not ca_id.startswith('CA'):
+        # build the output
+        out_batch = []
+        if results:
+            result_index = 0
+            for lnum, line, input_data, secondary_data in batch:
+                if lnum in lines_to_skip:
+                    # remember to skip 2k up/down variants
+                    out_batch.append((lnum, line, input_data, secondary_data, {'allele_registry_id': ''}))
+                    continue
+
+                result = results[result_index]
+                result_index += 1
+                full_id = result.get('@id')
                 ca_id = ''
-            out = {
-                'allele_registry_id': ca_id
-            }
-        return out
+                if full_id:
+                    ca_id = str.split(full_id, '/')[-1]
+                    # cleanup error values
+                    if ca_id and not ca_id.startswith('CA'):
+                        ca_id = ''
+                out = {
+                    'allele_registry_id': ca_id
+                }
+                out_batch.append((lnum, line, input_data, secondary_data, out))
+        return out_batch
 
-    
+
 if __name__ == '__main__':
     annotator = CravatAnnotator(sys.argv)
     annotator.run()

--- a/annotators/clingen_allele_registry/clingen_allele_registry.yml
+++ b/annotators/clingen_allele_registry/clingen_allele_registry.yml
@@ -11,7 +11,8 @@ developer:
   website: https://clinicalgenome.org/
 level: variant
 input_format: crx
-api_url: https://reg.clinicalgenome.org/allele?hgvs=
+api_url: http://reg.clinicalgenome.org/alleles?file=hgvs
+batch_size: 100000
 output_columns:
 - name: allele_registry_id
   title: Allele Registry ID
@@ -35,9 +36,10 @@ tags:
 - variants
 title: ClinGen Allele Registry
 type: annotator
-requires_opencravat: '>=1.4.0'
-version: 1.1.1
+requires_opencravat: '>=2.14.0'
+version: 1.2.0
 release_note:
+  1.2.0: Update to use new OC batch annotation
   1.1.1: Fix for 2k upstream / downstream variants
   1.1.0: Change data source to call API
   1.0.0: New annotator for the ClinGen Allele Registry


### PR DESCRIPTION
* 100,000 variants per batch
* Note this requires an update to OC, make sure the version matches