### PR TITLE
Fix divide by zero errors in gnomad4 and alfa

### DIFF
--- a/annotators/alfa/alfa.py
+++ b/annotators/alfa/alfa.py
@@ -4,6 +4,10 @@ from cravat import InvalidData
 import sqlite3
 import os
 
+def _af(ac, an):
+    return ac / an if an > 0 else None
+
+
 class CravatAnnotator(BaseAnnotator):
     def annotate(self, input_data, secondary_data=None):
         out = {}
@@ -15,7 +19,7 @@ class CravatAnnotator(BaseAnnotator):
             total = str(row[0]).split(':')
             total_total = int(total[0])
             total_alt  = int(total[1])
-            total_freq = total_alt/total_total
+            total_freq = _af(total_alt, total_total)
             out['total_alt'] = total_alt
             out['total_freq'] = total_freq
             return out

--- a/annotators/gnomad4/gnomad4.py
+++ b/annotators/gnomad4/gnomad4.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import tabix
 
 
+def _af(ac, an):
+    return ac / an if an > 0 else None
+
+
 class CravatAnnotator(BaseAnnotator):
 
     def setup(self):
@@ -77,52 +81,52 @@ class CravatAnnotator(BaseAnnotator):
             return
         out = {
             # African
-            'af_afr': oc_data_d['AC_joint_afr']/oc_data_d['AN_joint_afr'],
+            'af_afr': _af(oc_data_d['AC_joint_afr'], oc_data_d['AN_joint_afr']),
             'an_afr': oc_data_d['AN_joint_afr'],
             'ac_afr': oc_data_d['AC_joint_afr'],
             'nhomalt_afr': oc_data_d['nhomalt_joint_afr'],
             # Amish
-            'af_ami': oc_data_d['AC_joint_ami']/oc_data_d['AN_joint_ami'],
+            'af_ami': _af(oc_data_d['AC_joint_ami'], oc_data_d['AN_joint_ami']),
             'an_ami': oc_data_d['AN_joint_ami'],
             'ac_ami': oc_data_d['AC_joint_ami'],
             'nhomalt_ami': oc_data_d['nhomalt_joint_ami'],
             # Ad-Mixed American
-            'af_amr': oc_data_d['AC_joint_amr']/oc_data_d['AN_joint_amr'],
+            'af_amr': _af(oc_data_d['AC_joint_amr'], oc_data_d['AN_joint_amr']),
             'an_amr': oc_data_d['AN_joint_amr'],
             'ac_amr': oc_data_d['AC_joint_amr'],
             'nhomalt_amr': oc_data_d['nhomalt_joint_amr'],
             # Ashkenazi Jewish
-            'af_asj': oc_data_d['AC_joint_asj']/oc_data_d['AN_joint_asj'],
+            'af_asj': _af(oc_data_d['AC_joint_asj'], oc_data_d['AN_joint_asj']),
             'an_asj': oc_data_d['AN_joint_asj'],
             'ac_asj': oc_data_d['AC_joint_asj'],
             'nhomalt_asj': oc_data_d['nhomalt_joint_asj'],
             # East Asian
-            'af_eas': oc_data_d['AC_joint_eas']/oc_data_d['AN_joint_eas'],
+            'af_eas': _af(oc_data_d['AC_joint_eas'], oc_data_d['AN_joint_eas']),
             'an_eas': oc_data_d['AN_joint_eas'],
             'ac_eas': oc_data_d['AC_joint_eas'],
             'nhomalt_eas': oc_data_d['nhomalt_joint_eas'],
             # Finnish
-            'af_fin': oc_data_d['AC_joint_fin']/oc_data_d['AN_joint_fin'],
+            'af_fin': _af(oc_data_d['AC_joint_fin'], oc_data_d['AN_joint_fin']),
             'an_fin': oc_data_d['AN_joint_fin'],
             'ac_fin': oc_data_d['AC_joint_fin'],
             'nhomalt_fin': oc_data_d['nhomalt_joint_fin'],
             # Middle Eastern
-            'af_mid': oc_data_d['AC_joint_mid']/oc_data_d['AN_joint_mid'],
+            'af_mid': _af(oc_data_d['AC_joint_mid'], oc_data_d['AN_joint_mid']),
             'an_mid': oc_data_d['AN_joint_mid'],
             'ac_mid': oc_data_d['AC_joint_mid'],
             'nhomalt_mid': oc_data_d['nhomalt_joint_mid'],
             # Non-Finnish European
-            'af_nfe': oc_data_d['AC_joint_nfe']/oc_data_d['AN_joint_nfe'],
+            'af_nfe': _af(oc_data_d['AC_joint_nfe'], oc_data_d['AN_joint_nfe']),
             'an_nfe': oc_data_d['AN_joint_nfe'],
             'ac_nfe': oc_data_d['AC_joint_nfe'],
             'nhomalt_nfe': oc_data_d['nhomalt_joint_nfe'],
             # South Asian
-            'af_sas': oc_data_d['AC_joint_sas']/oc_data_d['AN_joint_sas'],
+            'af_sas': _af(oc_data_d['AC_joint_sas'], oc_data_d['AN_joint_sas']),
             'an_sas': oc_data_d['AN_joint_sas'],
             'ac_sas': oc_data_d['AC_joint_sas'],
             'nhomalt_sas': oc_data_d['nhomalt_joint_sas'],
             # Remaining
-            'af_rem': oc_data_d['AC_joint_remaining']/oc_data_d['AN_joint_remaining'],
+            'af_rem': _af(oc_data_d['AC_joint_remaining'], oc_data_d['AN_joint_remaining']),
             'an_rem': oc_data_d['AN_joint_remaining'],
             'ac_rem': oc_data_d['AC_joint_remaining'],
             'nhomalt_rem': oc_data_d['nhomalt_joint_remaining'],
@@ -130,7 +134,7 @@ class CravatAnnotator(BaseAnnotator):
         out['an'] = sum(oc_data_l[0:10])
         out['ac'] = sum(oc_data_l[10:20])
         out['nhomalt'] = sum(oc_data_l[20:30])
-        out['af'] = out['ac']/out['an']
+        out['af'] = _af(out['ac'], out['an'])
         return out
     
     def cleanup(self):

--- a/annotators/gnomad4/gnomad4.yml
+++ b/annotators/gnomad4/gnomad4.yml
@@ -237,6 +237,7 @@ tags:
 - allele frequency
 
 release_note:
+  4.1.4: Prevent rare crash from zero depth sites
   4.1.3: Patch missing data (data change only)
   4.1.2: Add AC, AN, nhomalt columns
   4.1.1: Fix annotation of indels


### PR DESCRIPTION
Some allele populations will have a total count of zero, resulting in a division by zero in the annotator when calculating the allele frequency. This is visible in the logs for the annotator.

This PR adds a guarded division, returning `None` if the denominator is not there, and eliminating the error messages.