### PR TITLE
[OC-783] convert gnomad4 annotator to run off of sqlite

### DIFF
--- a/annotators/gnomad4/convert_to_sqlite.py
+++ b/annotators/gnomad4/convert_to_sqlite.py
@@ -1,0 +1,95 @@
+"""
+Convert gnomAD4 per-chromosome VCF.GZ files to SQLite databases.
+
+Usage:
+    python convert_to_sqlite.py [data_dir]
+
+data_dir defaults to the current directory. Produces one .sqlite file
+per .vcf.gz file alongside the originals. The VCF.GZ files are not removed.
+"""
+
+import gzip
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+OC_RE = re.compile(r'OC_DATA=([^;]+)')
+
+CREATE_SQL = '''
+    CREATE TABLE gnomad4 (
+        pos INTEGER NOT NULL,
+        ref TEXT NOT NULL,
+        alt TEXT NOT NULL,
+        %s
+    )
+''' % ', '.join(f'v{i} INTEGER' for i in range(30))
+
+INSERT_SQL = 'INSERT INTO gnomad4 VALUES (%s)' % ', '.join('?' * 33)
+
+
+def convert(vcf_gz_path: Path) -> None:
+    db_path = vcf_gz_path.with_suffix('').with_suffix('.sqlite')
+    if db_path.exists():
+        print(f'  {db_path.name} already exists, skipping (delete it to reconvert)')
+        return
+
+    print(f'Converting {vcf_gz_path.name} -> {db_path.name} ...', flush=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute('PRAGMA page_size = 4096')
+        conn.execute('PRAGMA journal_mode = OFF')   # safe for a fresh build
+        conn.execute('PRAGMA synchronous = OFF')
+        conn.execute(CREATE_SQL)
+
+        rows = []
+        total = 0
+        with gzip.open(str(vcf_gz_path), 'rt') as f:
+            conn.execute('BEGIN')
+            for line in f:
+                if line.startswith('#'):
+                    continue
+                fields = line.split('\t', 8)
+                m = OC_RE.search(fields[7])
+                if not m:
+                    continue
+                vals = m.group(1).split(',')
+                if len(vals) != 30:
+                    continue
+                rows.append((int(fields[1]), fields[3], fields[4], *(int(v) for v in vals)))
+                if len(rows) >= 50_000:
+                    conn.executemany(INSERT_SQL, rows)
+                    total += len(rows)
+                    rows.clear()
+                    print(f'  {total:,} rows ...', end='\r', flush=True)
+            if rows:
+                conn.executemany(INSERT_SQL, rows)
+                total += len(rows)
+            conn.execute('COMMIT')
+
+        print(f'  {total:,} rows inserted, building index ...', flush=True)
+        conn.execute('CREATE INDEX idx ON gnomad4 (pos, ref, alt)')
+        conn.execute('PRAGMA journal_mode = DELETE')
+        conn.execute('PRAGMA optimize')
+        print(f'  done: {db_path.name}', flush=True)
+    except Exception:
+        conn.close()
+        db_path.unlink(missing_ok=True)
+        raise
+    finally:
+        conn.close()
+
+
+def main():
+    data_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('.')
+    vcf_files = sorted(data_dir.glob('*.vcf.gz'))
+    if not vcf_files:
+        print(f'No .vcf.gz files found in {data_dir}')
+        sys.exit(1)
+    for vcf in vcf_files:
+        convert(vcf)
+    print('All done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/annotators/gnomad4/gnomad4.py
+++ b/annotators/gnomad4/gnomad4.py
@@ -1,145 +1,62 @@
 import sys
-import os
-from cravat import BaseAnnotator
-from cravat import InvalidData
 import sqlite3
+from cravat import BaseAnnotator
 from pathlib import Path
-import tabix
 
 
 def _af(ac, an):
     return ac / an if an > 0 else None
 
 
+_QUERY = 'SELECT ' + ','.join(f'v{i}' for i in range(30)) + \
+         ' FROM gnomad4 WHERE pos=? AND ref=? AND alt=? LIMIT 1'
+
+
 class CravatAnnotator(BaseAnnotator):
 
     def setup(self):
-        self.tabix_archives = {}
+        self.db_cursors = {}
         data_path = Path(self.data_dir)
-        for item in data_path.glob('*.vcf.gz'):
-            chrom = item.name.split('.')[0]
-            self.tabix_archives[chrom] = tabix.open(str(item))
-        self.key_order = [
-            'AN_joint_afr',
-            'AN_joint_ami',
-            'AN_joint_amr',
-            'AN_joint_asj',
-            'AN_joint_eas',
-            'AN_joint_fin',
-            'AN_joint_mid',
-            'AN_joint_nfe',
-            'AN_joint_sas',
-            'AN_joint_remaining',
-            'AC_joint_afr',
-            'AC_joint_ami',
-            'AC_joint_amr',
-            'AC_joint_asj',
-            'AC_joint_eas',
-            'AC_joint_fin',
-            'AC_joint_mid',
-            'AC_joint_nfe',
-            'AC_joint_sas',
-            'AC_joint_remaining',
-            'nhomalt_joint_afr',
-            'nhomalt_joint_ami',
-            'nhomalt_joint_amr',
-            'nhomalt_joint_asj',
-            'nhomalt_joint_eas',
-            'nhomalt_joint_fin',
-            'nhomalt_joint_mid',
-            'nhomalt_joint_nfe',
-            'nhomalt_joint_sas',
-            'nhomalt_joint_remaining'
-        ]
+        for db_path in data_path.glob('*.sqlite'):
+            chrom = db_path.stem
+            # mode=ro prevents accidental writes and avoids NFS write-lock issues
+            conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
+            conn.execute('PRAGMA cache_size=-16384')  # 16 MB per chromosome
+            conn.execute('PRAGMA temp_store=MEMORY')
+            conn.execute('PRAGMA mmap_size=0')        # disable mmap; unreliable on NFS
+            self.db_cursors[chrom] = conn.cursor()
 
-    def annotate(self, input_data):
+    def _make_output(self, row):
+        # row: (v0..v29) = AN[0:10], AC[10:20], nhomalt[20:30]
+        # population order: afr ami amr asj eas fin mid nfe sas rem
+        pops = ('afr', 'ami', 'amr', 'asj', 'eas', 'fin', 'mid', 'nfe', 'sas', 'rem')
         out = {}
-        chrom = input_data['chrom']
-        pos = input_data['pos']
-        ref = input_data['ref_base']
-        alt = input_data['alt_base']
-        if chrom not in self.tabix_archives:
-            return
-        records = list(self.tabix_archives[chrom].query(chrom, pos - 1, pos))
-        if len(records) == 0:
-            return
-        oc_data_l = None
-        oc_data_d = None
-        for record in records:
-            if pos == int(record[1]) and ref == record[3] and alt == record[4]:
-                for info_item in record[7].split(';'):
-                    info_toks = info_item.split('=')
-                    if info_toks[0] == 'OC_DATA':
-                        oc_data_l = [int(_) for _ in info_toks[1].split(',')]
-                        oc_data_d = dict(zip(
-                            self.key_order,
-                            oc_data_l,
-                        ))
-                        break
-                break
-        if oc_data_l is None or oc_data_d is None:
-            return
-        out = {
-            # African
-            'af_afr': _af(oc_data_d['AC_joint_afr'], oc_data_d['AN_joint_afr']),
-            'an_afr': oc_data_d['AN_joint_afr'],
-            'ac_afr': oc_data_d['AC_joint_afr'],
-            'nhomalt_afr': oc_data_d['nhomalt_joint_afr'],
-            # Amish
-            'af_ami': _af(oc_data_d['AC_joint_ami'], oc_data_d['AN_joint_ami']),
-            'an_ami': oc_data_d['AN_joint_ami'],
-            'ac_ami': oc_data_d['AC_joint_ami'],
-            'nhomalt_ami': oc_data_d['nhomalt_joint_ami'],
-            # Ad-Mixed American
-            'af_amr': _af(oc_data_d['AC_joint_amr'], oc_data_d['AN_joint_amr']),
-            'an_amr': oc_data_d['AN_joint_amr'],
-            'ac_amr': oc_data_d['AC_joint_amr'],
-            'nhomalt_amr': oc_data_d['nhomalt_joint_amr'],
-            # Ashkenazi Jewish
-            'af_asj': _af(oc_data_d['AC_joint_asj'], oc_data_d['AN_joint_asj']),
-            'an_asj': oc_data_d['AN_joint_asj'],
-            'ac_asj': oc_data_d['AC_joint_asj'],
-            'nhomalt_asj': oc_data_d['nhomalt_joint_asj'],
-            # East Asian
-            'af_eas': _af(oc_data_d['AC_joint_eas'], oc_data_d['AN_joint_eas']),
-            'an_eas': oc_data_d['AN_joint_eas'],
-            'ac_eas': oc_data_d['AC_joint_eas'],
-            'nhomalt_eas': oc_data_d['nhomalt_joint_eas'],
-            # Finnish
-            'af_fin': _af(oc_data_d['AC_joint_fin'], oc_data_d['AN_joint_fin']),
-            'an_fin': oc_data_d['AN_joint_fin'],
-            'ac_fin': oc_data_d['AC_joint_fin'],
-            'nhomalt_fin': oc_data_d['nhomalt_joint_fin'],
-            # Middle Eastern
-            'af_mid': _af(oc_data_d['AC_joint_mid'], oc_data_d['AN_joint_mid']),
-            'an_mid': oc_data_d['AN_joint_mid'],
-            'ac_mid': oc_data_d['AC_joint_mid'],
-            'nhomalt_mid': oc_data_d['nhomalt_joint_mid'],
-            # Non-Finnish European
-            'af_nfe': _af(oc_data_d['AC_joint_nfe'], oc_data_d['AN_joint_nfe']),
-            'an_nfe': oc_data_d['AN_joint_nfe'],
-            'ac_nfe': oc_data_d['AC_joint_nfe'],
-            'nhomalt_nfe': oc_data_d['nhomalt_joint_nfe'],
-            # South Asian
-            'af_sas': _af(oc_data_d['AC_joint_sas'], oc_data_d['AN_joint_sas']),
-            'an_sas': oc_data_d['AN_joint_sas'],
-            'ac_sas': oc_data_d['AC_joint_sas'],
-            'nhomalt_sas': oc_data_d['nhomalt_joint_sas'],
-            # Remaining
-            'af_rem': _af(oc_data_d['AC_joint_remaining'], oc_data_d['AN_joint_remaining']),
-            'an_rem': oc_data_d['AN_joint_remaining'],
-            'ac_rem': oc_data_d['AC_joint_remaining'],
-            'nhomalt_rem': oc_data_d['nhomalt_joint_remaining'],
-        }
-        out['an'] = sum(oc_data_l[0:10])
-        out['ac'] = sum(oc_data_l[10:20])
-        out['nhomalt'] = sum(oc_data_l[20:30])
+        for i, pop in enumerate(pops):
+            an, ac, nh = row[i], row[i + 10], row[i + 20]
+            out[f'an_{pop}'] = an
+            out[f'ac_{pop}'] = ac
+            out[f'nhomalt_{pop}'] = nh
+            out[f'af_{pop}'] = _af(ac, an)
+        out['an'] = sum(row[0:10])
+        out['ac'] = sum(row[10:20])
+        out['nhomalt'] = sum(row[20:30])
         out['af'] = _af(out['ac'], out['an'])
         return out
-    
+
+    def annotate(self, input_data):
+        cursor = self.db_cursors.get(input_data['chrom'])
+        if cursor is None:
+            return
+        cursor.execute(_QUERY, (input_data['pos'], input_data['ref_base'], input_data['alt_base']))
+        row = cursor.fetchone()
+        if row is None:
+            return
+        return self._make_output(row)
+
     def cleanup(self):
         pass
-        
+
+
 if __name__ == '__main__':
     annotator = CravatAnnotator(sys.argv)
     annotator.run()

--- a/annotators/gnomad4/gnomad4.yml
+++ b/annotators/gnomad4/gnomad4.yml
@@ -1,6 +1,6 @@
 title: gnomAD4
 type: annotator
-version: 4.1.4
+version: 4.1.5
 datasource: v4.1
 description: Genome Aggregation Database (gnomAD) is a resource developed by an international
   coalition of investigators, with the goal of aggregating and harmonizing both exome
@@ -237,6 +237,7 @@ tags:
 - allele frequency
 
 release_note:
+  4.1.5: Convert to SQLite annotator data
   4.1.4: Prevent rare crash from zero depth sites
   4.1.3: Patch missing data (data change only)
   4.1.2: Add AC, AN, nhomalt columns


### PR DESCRIPTION
## Summary

On a test dataset of ~1.4 million variants, on a weka network filesystem, annotation time went from 45 minutes to 5 minutes by switching the backing data to SQLite.

## Previous behavior

Annotator data for gnomad4 was stored in compact tabix files, taking approximately 22GB

## New behavior

Roughly 10x speedup, 3x data size increase from 22GB to 66GB

- Annotator: use sqlite version of gnomad4 data, 
- conversion script for creating sqlite databases
- guard against division by zero at zero depth sites
- bump gnomad4 version
- 
## Tests / to do
- [x] run on a large cohort of variants, finding the expected amount of annotations pre- and post-sqlite conversion
- [ ] run included annotator tests
- [ ] remove conversion script

